### PR TITLE
feat: parse HTML front matter

### DIFF
--- a/lib/parse-page.js
+++ b/lib/parse-page.js
@@ -1,0 +1,176 @@
+import { parse as parseToml } from "jsr:@std/toml";
+
+const TOP_LEVEL_KEYS = [
+  "title",
+  "description",
+  "css",
+  "templates",
+  "scripts",
+  "links",
+];
+const TEMPLATE_KEYS = ["head", "nav", "footer"];
+const SCRIPT_KEYS = ["modules", "inline"];
+const LINK_SECTIONS = ["nav", "footer"];
+const NAV_LINK_KEYS = ["topLevel", "subLevel", "label"];
+const FOOTER_LINK_KEYS = ["column", "label"];
+
+/**
+ * Parse an HTML file with TOML front-matter.
+ *
+ * Splits the file at `#---#`, parses the first segment as TOML and validates
+ * recognised keys. Unknown keys log a warning. Returns the parsed front-matter
+ * alongside the remaining HTML.
+ */
+export async function parsePage(path) {
+  const raw = await Deno.readTextFile(path);
+  const separator = "#---#";
+  const idx = raw.indexOf(separator);
+  if (idx === -1) {
+    throw new Error(`${path}: missing \"${separator}\" separator`);
+  }
+  const tomlText = raw.slice(0, idx).trim();
+  const html = raw.slice(idx + separator.length);
+  let frontMatter = {};
+  if (tomlText.length > 0) {
+    try {
+      frontMatter = parseToml(tomlText);
+    } catch (err) {
+      if (err instanceof Error) {
+        err.message = `${path}: ${err.message}`;
+      }
+      throw err;
+    }
+  }
+  validateFrontMatter(frontMatter, path);
+  return {
+    frontMatter,
+    templates: frontMatter.templates ?? {},
+    scripts: frontMatter.scripts ?? {},
+    links: frontMatter.links ?? {},
+    html,
+  };
+}
+
+function validateFrontMatter(fm, path) {
+  for (const key of Object.keys(fm)) {
+    if (!TOP_LEVEL_KEYS.includes(key)) {
+      console.warn(`${path}: unknown front-matter key \"${key}\"`);
+    }
+  }
+
+  if (typeof fm.title !== "string") {
+    throw new Error(`${path}: \"title\" is required and must be a string`);
+  }
+  if (fm.description !== undefined && typeof fm.description !== "string") {
+    throw new Error(`${path}: \"description\" must be a string`);
+  }
+  if (fm.css !== undefined) {
+    if (!Array.isArray(fm.css) || fm.css.some((v) => typeof v !== "string")) {
+      throw new Error(`${path}: \"css\" must be an array of strings`);
+    }
+  }
+
+  const templates = fm.templates;
+  if (typeof templates !== "object" || templates === null) {
+    throw new Error(`${path}: \"templates\" table is required`);
+  }
+  for (const key of Object.keys(templates)) {
+    if (!TEMPLATE_KEYS.includes(key)) {
+      console.warn(`${path}: unknown \"templates.${key}\" key`);
+    }
+  }
+  if (typeof templates.head !== "string") {
+    throw new Error(
+      `${path}: \"templates.head\" is required and must be a string`,
+    );
+  }
+  if (templates.nav !== undefined && typeof templates.nav !== "string") {
+    throw new Error(`${path}: \"templates.nav\" must be a string`);
+  }
+  if (templates.footer !== undefined && typeof templates.footer !== "string") {
+    throw new Error(`${path}: \"templates.footer\" must be a string`);
+  }
+
+  const scripts = fm.scripts;
+  if (scripts !== undefined) {
+    if (typeof scripts !== "object" || scripts === null) {
+      throw new Error(`${path}: \"scripts\" must be a table`);
+    }
+    for (const key of Object.keys(scripts)) {
+      if (!SCRIPT_KEYS.includes(key)) {
+        console.warn(`${path}: unknown \"scripts.${key}\" key`);
+      }
+    }
+    if (scripts.modules !== undefined) {
+      if (
+        !Array.isArray(scripts.modules) ||
+        scripts.modules.some((v) => typeof v !== "string")
+      ) {
+        throw new Error(
+          `${path}: \"scripts.modules\" must be an array of strings`,
+        );
+      }
+    }
+    if (scripts.inline !== undefined) {
+      if (
+        !Array.isArray(scripts.inline) ||
+        scripts.inline.some((v) => typeof v !== "string")
+      ) {
+        throw new Error(
+          `${path}: \"scripts.inline\" must be an array of strings`,
+        );
+      }
+    }
+  }
+
+  const links = fm.links;
+  if (links !== undefined) {
+    if (typeof links !== "object" || links === null) {
+      throw new Error(`${path}: \"links\" must be a table`);
+    }
+    for (const key of Object.keys(links)) {
+      if (!LINK_SECTIONS.includes(key)) {
+        console.warn(`${path}: unknown \"links.${key}\" key`);
+      }
+    }
+
+    const nav = links.nav;
+    if (nav !== undefined) {
+      if (typeof nav !== "object" || nav === null) {
+        throw new Error(`${path}: \"links.nav\" must be a table`);
+      }
+      for (const key of Object.keys(nav)) {
+        if (!NAV_LINK_KEYS.includes(key)) {
+          console.warn(`${path}: unknown \"links.nav.${key}\" key`);
+        }
+      }
+      if (nav.topLevel !== undefined && typeof nav.topLevel !== "boolean") {
+        throw new Error(`${path}: \"links.nav.topLevel\" must be a boolean`);
+      }
+      if (nav.subLevel !== undefined && typeof nav.subLevel !== "string") {
+        throw new Error(`${path}: \"links.nav.subLevel\" must be a string`);
+      }
+      if (nav.label !== undefined && typeof nav.label !== "string") {
+        throw new Error(`${path}: \"links.nav.label\" must be a string`);
+      }
+    }
+
+    const footer = links.footer;
+    if (footer !== undefined) {
+      if (typeof footer !== "object" || footer === null) {
+        throw new Error(`${path}: \"links.footer\" must be a table`);
+      }
+      for (const key of Object.keys(footer)) {
+        if (!FOOTER_LINK_KEYS.includes(key)) {
+          console.warn(`${path}: unknown \"links.footer.${key}\" key`);
+        }
+      }
+      if (footer.column !== undefined && typeof footer.column !== "string") {
+        throw new Error(`${path}: \"links.footer.column\" must be a string`);
+      }
+      if (footer.label !== undefined && typeof footer.label !== "string") {
+        throw new Error(`${path}: \"links.footer.label\" must be a string`);
+      }
+    }
+  }
+}

--- a/lib/parse-page.test.js
+++ b/lib/parse-page.test.js
@@ -1,0 +1,35 @@
+import { parsePage } from "./parse-page.js";
+import { assertEquals } from "jsr:@std/assert";
+import { stub } from "jsr:@std/testing/mock";
+
+Deno.test("parsePage extracts front-matter and html", async () => {
+  const tmp = await Deno.makeTempFile({ suffix: ".html" });
+  const content = `title = "Hello"
+[templates]
+head = "default"
+#---#
+<body>Hi</body>`;
+  await Deno.writeTextFile(tmp, content);
+  const result = await parsePage(tmp);
+  assertEquals(result.frontMatter.title, "Hello");
+  assertEquals(result.templates.head, "default");
+  assertEquals(result.html.trim(), "<body>Hi</body>");
+});
+
+Deno.test("warns on unknown keys", async () => {
+  const tmp = await Deno.makeTempFile({ suffix: ".html" });
+  const content = `title = "X"
+foo = 1
+[templates]
+head = "x"
+#---#
+<p></p>`;
+  await Deno.writeTextFile(tmp, content);
+  const warn = stub(console, "warn");
+  try {
+    await parsePage(tmp);
+    assertEquals(warn.calls.length, 1);
+  } finally {
+    warn.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- parse page front matter separated by `#---#`
- validate expected front-matter keys and warn on unknown ones
- expose parsed templates, scripts, and links for later pipeline steps

## Testing
- `deno fmt lib/parse-page.js lib/parse-page.test.js`
- `deno lint lib/parse-page.js lib/parse-page.test.js`
- `deno test --unsafely-ignore-certificate-errors=jsr.io --allow-read --allow-write lib/parse-page.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688e645a958c8331a8150c9ae3705486