### PR TITLE
feat: render templates from front matter

### DIFF
--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -1,0 +1,45 @@
+/**
+ * Resolve template names from front matter and inject rendered HTML.
+ *
+ * @param {Document} doc       - DOM document to mutate.
+ * @param {object} frontMatter - Parsed front-matter object.
+ * @param {object} links       - Parsed links.json object.
+ * @param {URL} [root]         - Base directory for templates as a file URL.
+ */
+export async function applyTemplates(doc, frontMatter, links, root = new URL("..", import.meta.url)) {
+  const slots = ["head", "nav", "footer"];
+  const templates = frontMatter.templates || {};
+
+  for (const slot of slots) {
+    const name = templates[slot];
+    if (!name) continue;
+
+    const moduleUrl = new URL(`templates/${slot}/${name}.js`, root);
+    const module = await import(moduleUrl.href);
+    if (typeof module.render !== "function") {
+      throw new Error(`Template ${slot}/${name} does not export render()`);
+    }
+    const html = module.render({ frontMatter, links });
+    if (typeof html !== "string") {
+      throw new Error(`Template ${slot}/${name} render() must return a string`);
+    }
+
+    if (slot === "head") {
+      let head = doc.head;
+      if (!head) {
+        head = doc.createElement("head");
+        doc.documentElement.prepend(head);
+      }
+      head.innerHTML = html + head.innerHTML;
+    } else if (slot === "nav") {
+      const body = doc.body;
+      if (!body) throw new Error("Document missing <body>");
+      body.innerHTML = html + body.innerHTML;
+    } else if (slot === "footer") {
+      const body = doc.body;
+      if (!body) throw new Error("Document missing <body>");
+      body.innerHTML = body.innerHTML + html;
+    }
+  }
+}
+

--- a/tests/apply-templates.test.js
+++ b/tests/apply-templates.test.js
@@ -1,0 +1,54 @@
+import { applyTemplates } from "../lib/apply-templates.js";
+
+function assertEquals(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`Assertion failed: expected ${expected}, got ${actual}`);
+  }
+}
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.innerHTML = "";
+  }
+}
+
+class StubDocument {
+  constructor() {
+    this.head = new Element("head");
+    this.body = new Element("body");
+    this.documentElement = {
+      prepend: (el) => {
+        this.head = el;
+      },
+    };
+  }
+  createElement(tag) {
+    return new Element(tag);
+  }
+}
+
+Deno.test("applyTemplates inserts rendered fragments", async () => {
+  const doc = new StubDocument();
+  doc.body.innerHTML = "<main>hi</main>";
+
+  const frontMatter = {
+    title: "Example",
+    templates: {
+      head: "default",
+      nav: "default",
+      footer: "default",
+    },
+  };
+  const links = { nav: [], footer: [] };
+
+  const root = new URL("./", import.meta.url);
+  await applyTemplates(doc, frontMatter, links, root);
+
+  assertEquals(doc.head.innerHTML, "<title>Example</title>");
+  assertEquals(
+    doc.body.innerHTML,
+    "<nav>nav</nav><main>hi</main><footer>foot</footer>",
+  );
+});
+

--- a/tests/templates/footer/default.js
+++ b/tests/templates/footer/default.js
@@ -1,0 +1,3 @@
+export function render() {
+  return `<footer>foot</footer>`;
+}

--- a/tests/templates/head/default.js
+++ b/tests/templates/head/default.js
@@ -1,0 +1,3 @@
+export function render({ frontMatter }) {
+  return `<title>${frontMatter.title}</title>`;
+}

--- a/tests/templates/nav/default.js
+++ b/tests/templates/nav/default.js
@@ -1,0 +1,3 @@
+export function render() {
+  return `<nav>nav</nav>`;
+}


### PR DESCRIPTION
## Summary
- dynamically resolve templates based on page front matter
- inject rendered head, nav, and footer fragments into documents
- add fixture templates and tests

## Testing
- `deno test --allow-read`


------
https://chatgpt.com/codex/tasks/task_e_688e669e27448331827262e9360b1ac4