### PR TITLE
feat: manage site links

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,0 +1,81 @@
+export class LinksManager {
+  constructor(path) {
+    this.path = path;
+    this.data = { nav: [], footer: [] };
+    this._original = "";
+  }
+
+  async load() {
+    try {
+      const text = await Deno.readTextFile(this.path);
+      this._original = text;
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed.nav)) this.data.nav = parsed.nav;
+      if (Array.isArray(parsed.footer)) this.data.footer = parsed.footer;
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) {
+        this._original = JSON.stringify(this.data, null, 2) + "\n";
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  merge(href, pageLinks) {
+    let changed = false;
+    if (pageLinks.nav) {
+      const item = { href, label: pageLinks.nav.label };
+      if (pageLinks.nav.topLevel) item.topLevel = true;
+      if (pageLinks.nav.subLevel !== undefined) {
+        item.subLevel = pageLinks.nav.subLevel;
+      }
+      const idx = this.data.nav.findIndex((l) => l.href === href);
+      if (idx >= 0) {
+        const prev = this.data.nav[idx];
+        if (!objectsEqual(prev, item)) {
+          this.data.nav[idx] = item;
+          changed = true;
+        }
+      } else {
+        this.data.nav.push(item);
+        changed = true;
+      }
+    }
+    if (pageLinks.footer) {
+      const item = { href, label: pageLinks.footer.label };
+      if (pageLinks.footer.column !== undefined) {
+        item.column = pageLinks.footer.column;
+      }
+      const idx = this.data.footer.findIndex((l) => l.href === href);
+      if (idx >= 0) {
+        const prev = this.data.footer[idx];
+        if (!objectsEqual(prev, item)) {
+          this.data.footer[idx] = item;
+          changed = true;
+        }
+      } else {
+        this.data.footer.push(item);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  async save() {
+    const json = JSON.stringify(this.data, null, 2) + "\n";
+    if (json !== this._original) {
+      await Deno.writeTextFile(this.path, json);
+      this._original = json;
+    }
+  }
+}
+
+function objectsEqual(a, b) {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}

--- a/lib/links.test.js
+++ b/lib/links.test.js
@@ -1,0 +1,42 @@
+import { LinksManager } from "./links.js";
+import { assertEquals } from "jsr:@std/assert";
+
+Deno.test("LinksManager merges links and writes only when changed", async () => {
+  const dir = await Deno.makeTempDir();
+  const path = `${dir}/links.json`;
+  await Deno.writeTextFile(
+    path,
+    JSON.stringify({ nav: [], footer: [] }, null, 2) + "\n",
+  );
+
+  const lm = new LinksManager(path);
+  await lm.load();
+
+  lm.merge("/about.html", { nav: { topLevel: true, label: "About" } });
+  lm.merge("/contact.html", {
+    footer: { column: "company", label: "Contact" },
+  });
+  await lm.save();
+
+  let text = await Deno.readTextFile(path);
+  let data = JSON.parse(text);
+  assertEquals(data.nav.length, 1);
+  assertEquals(data.nav[0].href, "/about.html");
+  assertEquals(data.nav[0].label, "About");
+  assertEquals(data.footer.length, 1);
+  assertEquals(data.footer[0].column, "company");
+
+  const m1 = (await Deno.stat(path)).mtime;
+
+  lm.merge("/about.html", { nav: { topLevel: true, label: "About" } });
+  await lm.save();
+  const m2 = (await Deno.stat(path)).mtime;
+  assertEquals(m1.getTime(), m2.getTime());
+
+  lm.merge("/about.html", { nav: { topLevel: true, label: "About Us" } });
+  await lm.save();
+  text = await Deno.readTextFile(path);
+  data = JSON.parse(text);
+  assertEquals(data.nav.length, 1);
+  assertEquals(data.nav[0].label, "About Us");
+});


### PR DESCRIPTION
## Summary
- add LinksManager to handle site-wide links.json
- merge front-matter link info and dedupe by href
- persist links.json only when content changes

## Testing
- `deno test -A --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688e6a655d9c83319ddc20cca189684a