### PR TITLE
Implement SVG inlining for icon and logo nodes

### DIFF
--- a/lib/inline-svg.js
+++ b/lib/inline-svg.js
@@ -1,0 +1,27 @@
+/**
+ * Replace <icon> and <logo> elements with inline SVG content.
+ *
+ * @param {Document} doc - DOM document to mutate.
+ * @param {URL} [root] - Base directory for locating src-svg/ folder.
+ */
+export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
+  const base = new URL("src-svg/", root);
+  const nodes = doc.querySelectorAll("icon, logo");
+  for (const node of nodes) {
+    const src = node.getAttribute("src");
+    if (!src) continue;
+    const fileUrl = new URL(src, base);
+    let svg;
+    try {
+      svg = await Deno.readTextFile(fileUrl);
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) {
+        console.error(`Missing SVG: ${fileUrl.pathname}`);
+        continue;
+      }
+      throw err;
+    }
+    node.outerHTML = svg;
+  }
+}
+

--- a/lib/inline-svg.test.js
+++ b/lib/inline-svg.test.js
@@ -1,0 +1,64 @@
+import { inlineSvg } from "./inline-svg.js";
+
+function assertEquals(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`Assertion failed: expected ${expected}, got ${actual}`);
+  }
+}
+
+class StubElement {
+  constructor(tag, src) {
+    this.tagName = tag;
+    this._src = src;
+    this._outerHTML = `<${tag} src="${src}" />`;
+  }
+  getAttribute(name) {
+    return name === "src" ? this._src : null;
+  }
+  set outerHTML(value) {
+    this._outerHTML = value;
+  }
+  get outerHTML() {
+    return this._outerHTML;
+  }
+}
+
+class StubDocument {
+  constructor(elements) {
+    this.elements = elements;
+  }
+  querySelectorAll(selector) {
+    const tags = selector.split(",").map((s) => s.trim());
+    return this.elements.filter((el) => tags.includes(el.tagName));
+  }
+}
+
+Deno.test("inlineSvg replaces node with SVG content", async () => {
+  const root = await Deno.makeTempDir();
+  await Deno.mkdir(`${root}/src-svg`, { recursive: true });
+  await Deno.writeTextFile(`${root}/src-svg/check.svg`, "<svg>ok</svg>");
+  const el = new StubElement("icon", "check.svg");
+  const doc = new StubDocument([el]);
+  const rootUrl = new URL(root + "/", import.meta.url);
+  await inlineSvg(doc, rootUrl);
+  assertEquals(el.outerHTML, "<svg>ok</svg>");
+});
+
+Deno.test("inlineSvg logs error when SVG missing", async () => {
+  const root = await Deno.makeTempDir();
+  await Deno.mkdir(`${root}/src-svg`, { recursive: true });
+  const el = new StubElement("icon", "missing.svg");
+  const doc = new StubDocument([el]);
+  const rootUrl = new URL(root + "/", import.meta.url);
+  const errors = [];
+  const orig = console.error;
+  console.error = (msg) => errors.push(msg);
+  try {
+    await inlineSvg(doc, rootUrl);
+  } finally {
+    console.error = orig;
+  }
+  assertEquals(errors.length, 1);
+  assertEquals(el.outerHTML, '<icon src="missing.svg" />');
+});
+


### PR DESCRIPTION
## Summary
- inline `<icon>` and `<logo>` elements with SVG contents from `src-svg/`
- log an error when the referenced SVG file cannot be found
- add tests for successful inlining and missing SVG cases

## Testing
- `deno test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_688e6da76b5083319e221bd47848ad10