### PR TITLE
Implement page rendering pipeline with output, formatting, and tests

### DIFF
--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,0 +1,120 @@
+import {
+  dirname,
+  join,
+  relative,
+  toFileUrl,
+} from "https://deno.land/std@0.224.0/path/mod.ts";
+import { DOMParser } from "jsr:@b-fuze/deno-dom@0.1.56";
+import { parsePage } from "./parse-page.js";
+import { LinksManager } from "./links.js";
+import { applyTemplates } from "./apply-templates.js";
+import { inlineSvg } from "./inline-svg.js";
+
+export async function renderPage(path, root = new URL("..", import.meta.url)) {
+  try {
+    const page = await parsePage(path);
+
+    const siteDir = await findSiteRoot(path);
+    const configPath = join(siteDir, "config.json");
+    const configText = await Deno.readTextFile(configPath);
+    const config = JSON.parse(configText);
+    const distant = String(config.distantDirectory);
+
+    const linksManager = new LinksManager(join(siteDir, "links.json"));
+    await linksManager.load();
+    const rel = relative(siteDir, path).replace(/\\/g, "/");
+    if (Object.keys(page.links).length > 0) {
+      const href = "/" + rel;
+      const changed = linksManager.merge(href, page.links);
+      if (changed) await linksManager.save();
+    }
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(page.html, "text/html");
+    if (!doc) throw new Error(`${path}: invalid HTML`);
+
+    await applyTemplates(doc, page.frontMatter, linksManager.data, root);
+
+    let head = doc.head;
+    if (!head) {
+      head = doc.createElement("head");
+      doc.documentElement.prepend(head);
+    }
+    const body = doc.body;
+    if (!body) throw new Error(`${path}: Document missing <body>`);
+
+    for (const href of page.frontMatter.css ?? []) {
+      const link = doc.createElement("link");
+      link.setAttribute("rel", "stylesheet");
+      link.setAttribute("href", href);
+      head.appendChild(link);
+    }
+
+    for (const src of page.scripts.modules ?? []) {
+      const script = doc.createElement("script");
+      script.setAttribute("type", "module");
+      script.setAttribute("src", src);
+      body.appendChild(script);
+    }
+
+    for (const file of page.scripts.inline ?? []) {
+      const scriptPath = join(siteDir, file);
+      let content;
+      try {
+        content = await Deno.readTextFile(scriptPath);
+      } catch (err) {
+        if (err instanceof Error) err.message = `${scriptPath}: ${err.message}`;
+        throw err;
+      }
+      const script = doc.createElement("script");
+      script.textContent = content;
+      body.appendChild(script);
+    }
+
+    await inlineSvg(doc, toFileUrl(siteDir + "/"));
+
+    const outRel = rel.replace(/\\/g, "/").replace(/\.html?$/i, "") + ".html";
+    const outPath = join(distant, outRel);
+    await Deno.mkdir(dirname(outPath), { recursive: true });
+    const htmlOut = "<!DOCTYPE html>\n" + doc.documentElement.outerHTML;
+    await Deno.writeTextFile(outPath, htmlOut);
+
+    const fmtCmd = new Deno.Command(Deno.execPath(), {
+      args: ["fmt", outPath],
+      stdout: "null",
+      stderr: "piped",
+    });
+    const { code, stderr } = await fmtCmd.output();
+    if (code !== 0) {
+      throw new Error(
+        `${outPath}: ${new TextDecoder().decode(stderr).trim()}`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      if (!err.message.includes(path)) {
+        err.message = `${path}: ${err.message}`;
+      }
+      console.error(err);
+    } else {
+      console.error(err);
+    }
+  }
+}
+
+async function findSiteRoot(filePath) {
+  let dir = dirname(filePath);
+  while (true) {
+    try {
+      const stat = await Deno.stat(join(dir, "config.json"));
+      if (stat.isFile) return dir;
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`config.json not found for ${filePath}`);
+    }
+    dir = parent;
+  }
+}

--- a/tests/render-page.test.js
+++ b/tests/render-page.test.js
@@ -1,0 +1,87 @@
+import { renderPage } from "../lib/render-page.js";
+import { join, toFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { DOMParser } from "jsr:@b-fuze/deno-dom@0.1.56";
+
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+function assertEquals(a, b) {
+  const da = JSON.stringify(a);
+  const db = JSON.stringify(b);
+  if (da !== db) throw new Error(`Expected ${db}, got ${da}`);
+}
+
+Deno.test("renderPage renders page and updates links", async () => {
+  const root = await Deno.makeTempDir();
+  const rootUrl = toFileUrl(root + "/");
+  const siteDir = join(root, "mysite");
+  const distDir = join(root, "dist");
+  await Deno.mkdir(siteDir, { recursive: true });
+  await Deno.mkdir(distDir, { recursive: true });
+
+  await Deno.writeTextFile(
+    join(siteDir, "config.json"),
+    JSON.stringify({ distantDirectory: distDir }),
+  );
+  await Deno.writeTextFile(join(siteDir, "inline.js"), "console.log('hi');");
+  await Deno.mkdir(join(siteDir, "src-svg", "ui"), { recursive: true });
+  await Deno.writeTextFile(
+    join(siteDir, "src-svg", "ui", "check.svg"),
+    "<svg><path/></svg>",
+  );
+
+  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "head", "default.js"),
+    "export function render({ frontMatter }) { return `<title>${frontMatter.title}</title>`; }",
+  );
+  await Deno.writeTextFile(
+    join(root, "templates", "nav", "default.js"),
+    "export function render() { return `<nav>nav</nav>`; }",
+  );
+  await Deno.writeTextFile(
+    join(root, "templates", "footer", "default.js"),
+    "export function render() { return `<footer>foot</footer>`; }",
+  );
+
+  await Deno.mkdir(join(siteDir, "blog"), { recursive: true });
+  const pagePath = join(siteDir, "blog", "index.html");
+  const page =
+    `title = "Hello"\ncss = ["styles.css"]\n[scripts]\nmodules = ["/js/app.js"]\ninline = ["inline.js"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n[links.nav]\ntopLevel = true\nlabel = "Home"\n#---#\n<body><icon src="ui/check.svg"></icon></body>`;
+  await Deno.writeTextFile(pagePath, page);
+
+  await renderPage(pagePath, rootUrl);
+
+  const outPath = join(distDir, "blog", "index.html");
+  const html = await Deno.readTextFile(outPath);
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+  assert(doc);
+  assert(doc.querySelector("nav")?.textContent === "nav");
+  assert(doc.querySelector("footer")?.textContent === "foot");
+  assert(
+    doc.querySelector('link[rel="stylesheet"][href="styles.css"]'),
+  );
+  assert(
+    doc.querySelector('script[type="module"][src="/js/app.js"]'),
+  );
+  const inlineScript = Array.from(doc.querySelectorAll("script")).find(
+    (s) => !s.getAttribute("src"),
+  );
+  assert(inlineScript?.textContent.includes("console.log"));
+  assert(doc.querySelector("svg path"));
+
+  assert(html.includes("\n  <head>\n"));
+
+  const links = JSON.parse(
+    await Deno.readTextFile(join(siteDir, "links.json")),
+  );
+  assertEquals(links.nav.length, 1);
+  assertEquals(links.nav[0], {
+    href: "/blog/index.html",
+    label: "Home",
+    topLevel: true,
+  });
+});


### PR DESCRIPTION
## Summary
- add `renderPage` that parses front-matter, applies templates, injects assets, inlines SVG, writes HTML, and formats it with `deno fmt`
- include link merging and robust error reporting
- test full page rendering, HTML formatting, and links.json updates

## Testing
- `deno test --allow-read --allow-write --allow-net --allow-run --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688e6f91e5cc83318fad819692a0e2aa