### PR TITLE
feat: add filesystem watch orchestration

### DIFF
--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -1,0 +1,43 @@
+import {
+  dirname,
+  join,
+  relative,
+} from "https://deno.land/std@0.224.0/path/mod.ts";
+
+export async function copyAsset(path) {
+  try {
+    const siteDir = await findSiteRoot(path);
+    const rel = relative(siteDir, path).replace(/\\/g, "/");
+    const configPath = join(siteDir, "config.json");
+    const configText = await Deno.readTextFile(configPath);
+    const config = JSON.parse(configText);
+    const distant = String(config.distantDirectory);
+    const outPath = join(distant, rel);
+    await Deno.mkdir(dirname(outPath), { recursive: true });
+    await Deno.copyFile(path, outPath);
+  } catch (err) {
+    if (err instanceof Error) {
+      if (!err.message.includes(path)) err.message = `${path}: ${err.message}`;
+      console.error(err);
+    } else {
+      console.error(err);
+    }
+  }
+}
+
+async function findSiteRoot(filePath) {
+  let dir = dirname(filePath);
+  while (true) {
+    try {
+      const stat = await Deno.stat(join(dir, "config.json"));
+      if (stat.isFile) return dir;
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`config.json not found for ${filePath}`);
+    }
+    dir = parent;
+  }
+}

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -1,0 +1,23 @@
+import { walk } from "https://deno.land/std@0.224.0/fs/walk.ts";
+import { renderPage } from "./render-page.js";
+
+async function renderAllPages() {
+  const root = new URL("../src", import.meta.url);
+  try {
+    for await (
+      const entry of walk(root, { exts: [".html"], includeDirs: false })
+    ) {
+      await renderPage(entry.path);
+    }
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+}
+
+export async function renderAllUsingTemplate(_path) {
+  await renderAllPages();
+}
+
+export async function renderAllUsingSvg(_path) {
+  await renderAllPages();
+}

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,0 +1,108 @@
+import { fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { renderPage } from "./render-page.js";
+import { renderAllUsingSvg, renderAllUsingTemplate } from "./rebuild.js";
+import { copyAsset } from "./copy-asset.js";
+
+export async function watch() {
+  const src = fromFileUrl(new URL("../src", import.meta.url));
+  const templates = fromFileUrl(new URL("../templates", import.meta.url));
+
+  const watchers = [
+    Deno.watchFs(src, { recursive: true }),
+    Deno.watchFs(templates, { recursive: true }),
+  ];
+
+  const queue = [];
+  let timer;
+
+  async function flush() {
+    const events = queue.splice(0);
+    timer = undefined;
+    const paths = reduceEvents(events);
+    const tasks = new Map();
+    for (const [path] of paths) {
+      const kind = classifyPath(path);
+      if (kind === "PAGE_HTML") {
+        tasks.set(`page:${path}`, () => renderPage(path));
+      } else if (kind === "TEMPLATE") {
+        tasks.set(`tpl:${path}`, () => renderAllUsingTemplate(path));
+      } else if (kind === "SVG_INLINE") {
+        tasks.set(`svg:${path}`, () => renderAllUsingSvg(path));
+      } else if (kind === "ASSET") {
+        tasks.set(`asset:${path}`, () => copyAsset(path));
+      }
+    }
+    await Promise.all([...tasks.values()].map((fn) => fn()));
+  }
+
+  async function handle(w) {
+    for await (const evt of w) {
+      queue.push(evt);
+      if (!timer) timer = setTimeout(flush, 50);
+    }
+  }
+
+  await Promise.all(watchers.map(handle));
+}
+
+export function reduceEvents(events) {
+  const map = new Map();
+  for (const evt of events) {
+    for (const path of evt.paths) {
+      const prev = map.get(path);
+      if (!prev) {
+        map.set(path, evt.kind);
+      } else if (prev === evt.kind) {
+        continue;
+      } else if (prev === "create" && evt.kind === "modify") {
+        continue;
+      } else {
+        map.set(path, evt.kind);
+      }
+    }
+  }
+  return map;
+}
+
+export function classifyPath(path) {
+  const p = path.replace(/\\/g, "/");
+  const lower = p.toLowerCase();
+  if (lower.endsWith(".html")) return "PAGE_HTML";
+  if (lower.includes("/templates/") && lower.endsWith(".js")) return "TEMPLATE";
+  if (lower.includes("/src-svg/") && lower.endsWith(".svg")) {
+    return "SVG_INLINE";
+  }
+  if (lower.includes("/media/")) {
+    const ext = lower.slice(lower.lastIndexOf("."));
+    const mediaExts = new Set([
+      ".svg",
+      ".mp4",
+      ".jpg",
+      ".png",
+      ".webm",
+      ".webp",
+      ".pdf",
+      ".ttf",
+      ".otf",
+    ]);
+    if (mediaExts.has(ext)) return "ASSET";
+  }
+  if (lower.includes("/src/")) {
+    const ext = lower.slice(lower.lastIndexOf("."));
+    const assetExts = new Set([
+      ".css",
+      ".js",
+      ".svg",
+      ".mp4",
+      ".jpg",
+      ".png",
+      ".webm",
+      ".webp",
+      ".pdf",
+      ".ttf",
+      ".otf",
+    ]);
+    if (assetExts.has(ext)) return "ASSET";
+  }
+  return null;
+}

--- a/lib/watch.test.js
+++ b/lib/watch.test.js
@@ -1,0 +1,24 @@
+import { classifyPath, reduceEvents } from "./watch.js";
+import { assertEquals } from "jsr:@std/assert";
+
+denoTest();
+
+function denoTest() {
+  Deno.test("reduceEvents dedupes and promotes", () => {
+    const events = [
+      { kind: "create", paths: ["/a.html"] },
+      { kind: "modify", paths: ["/a.html"] },
+      { kind: "modify", paths: ["/a.html"] },
+    ];
+    const res = reduceEvents(events);
+    assertEquals(res.get("/a.html"), "create");
+  });
+
+  Deno.test("classifyPath identifies types", () => {
+    assertEquals(classifyPath("/src/site/page.html"), "PAGE_HTML");
+    assertEquals(classifyPath("/templates/head.js"), "TEMPLATE");
+    assertEquals(classifyPath("/src/site/src-svg/icon.svg"), "SVG_INLINE");
+    assertEquals(classifyPath("/src/site/js/app.js"), "ASSET");
+    assertEquals(classifyPath("/src/site/media/logo.png"), "ASSET");
+  });
+}


### PR DESCRIPTION
## Summary
- watch src and templates roots with debounced Deno.watchFs streams
- classify file events and schedule render or asset copy tasks
- basic helpers for asset copying and full re-render

## Testing
- `deno test -A --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688e7846abe483318675cd03a0e9d787