### PR TITLE
feat: add asset extension whitelist and worker-pooled copies

### DIFF
--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -3,26 +3,54 @@ import {
   join,
   relative,
 } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
 
-export async function copyAsset(path) {
-  try {
-    const siteDir = await findSiteRoot(path);
-    const rel = relative(siteDir, path).replace(/\\/g, "/");
-    const configPath = join(siteDir, "config.json");
-    const configText = await Deno.readTextFile(configPath);
-    const config = JSON.parse(configText);
-    const distant = String(config.distantDirectory);
-    const outPath = join(distant, rel);
-    await Deno.mkdir(dirname(outPath), { recursive: true });
-    await Deno.copyFile(path, outPath);
-  } catch (err) {
-    if (err instanceof Error) {
-      if (!err.message.includes(path)) err.message = `${path}: ${err.message}`;
-      console.error(err);
-    } else {
-      console.error(err);
-    }
-  }
+const MAX_WORKERS = navigator.hardwareConcurrency ?? 2;
+const queue = [];
+let active = 0;
+
+function runNext() {
+  if (active >= MAX_WORKERS) return;
+  const job = queue.shift();
+  if (!job) return;
+  active++;
+  copyOne(job.path)
+    .catch((err) => {
+      if (err instanceof Error) {
+        if (!err.message.includes(job.path)) {
+          err.message = `${job.path}: ${err.message}`;
+        }
+        console.error(err);
+      } else {
+        console.error(err);
+      }
+    })
+    .finally(() => {
+      active--;
+      job.resolve();
+      runNext();
+    });
+}
+
+export function copyAsset(path) {
+  const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+  if (!SRC_ASSET_EXTENSIONS.has(ext)) return Promise.resolve();
+  return new Promise((resolve) => {
+    queue.push({ path, resolve });
+    runNext();
+  });
+}
+
+async function copyOne(path) {
+  const siteDir = await findSiteRoot(path);
+  const rel = relative(siteDir, path).replace(/\\/g, "/");
+  const configPath = join(siteDir, "config.json");
+  const configText = await Deno.readTextFile(configPath);
+  const config = JSON.parse(configText);
+  const distant = String(config.distantDirectory);
+  const outPath = join(distant, rel);
+  await Deno.mkdir(dirname(outPath), { recursive: true });
+  await Deno.copyFile(path, outPath);
 }
 
 async function findSiteRoot(filePath) {

--- a/lib/copy-asset.test.js
+++ b/lib/copy-asset.test.js
@@ -1,0 +1,38 @@
+import { copyAsset } from "./copy-asset.js";
+import { assert, assertEquals } from "jsr:@std/assert";
+import { join, dirname } from "https://deno.land/std@0.224.0/path/mod.ts";
+
+Deno.test("copyAsset preserves relative path", async () => {
+  const root = await Deno.makeTempDir();
+  const distant = join(root, "dist");
+  await Deno.writeTextFile(join(root, "config.json"), JSON.stringify({ distantDirectory: distant }));
+  const srcFile = join(root, "css", "style.css");
+  await Deno.mkdir(dirname(srcFile), { recursive: true });
+  await Deno.writeTextFile(srcFile, "body{}");
+  await copyAsset(srcFile);
+  const outFile = join(distant, "css", "style.css");
+  const stat = await Deno.stat(outFile);
+  assert(stat.isFile);
+});
+
+Deno.test("copyAsset skips non-whitelisted extensions", async () => {
+  const root = await Deno.makeTempDir();
+  const distant = join(root, "dist");
+  await Deno.writeTextFile(join(root, "config.json"), JSON.stringify({ distantDirectory: distant }));
+  const srcFile = join(root, "notes.txt");
+  await Deno.writeTextFile(srcFile, "hello");
+  await copyAsset(srcFile);
+  const outFile = join(distant, "notes.txt");
+  const exists = await fileExists(outFile);
+  assertEquals(exists, false);
+});
+
+async function fileExists(path) {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
+  }
+}

--- a/lib/extension-whitelist.js
+++ b/lib/extension-whitelist.js
@@ -1,0 +1,18 @@
+export const EXT_WHITELIST = {
+  styles: [".css"],
+  scripts: [".js"],
+  images: [".svg", ".jpg", ".png", ".webp", ".ico"],
+  video: [".mp4", ".webm"],
+  documents: [".pdf"],
+  fonts: [".ttf", ".otf"],
+};
+
+export const MEDIA_EXTENSIONS = new Set(
+  [...EXT_WHITELIST.images, ...EXT_WHITELIST.video, ...EXT_WHITELIST.documents, ...EXT_WHITELIST.fonts].map((e) => e.toLowerCase()),
+);
+
+export const SRC_ASSET_EXTENSIONS = new Set(
+  [...EXT_WHITELIST.styles, ...EXT_WHITELIST.scripts, ...MEDIA_EXTENSIONS].map((e) => e.toLowerCase()),
+);
+
+export const ALL_EXTENSIONS = SRC_ASSET_EXTENSIONS;

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -2,33 +2,10 @@ import { fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { renderPage } from "./render-page.js";
 import { renderAllUsingSvg, renderAllUsingTemplate } from "./rebuild.js";
 import { copyAsset } from "./copy-asset.js";
-
-
-const MEDIA_EXTS = new Set([
-  ".svg",
-  ".mp4",
-  ".jpg",
-  ".png",
-  ".webm",
-  ".webp",
-  ".pdf",
-  ".ttf",
-  ".otf",
-]);
-
-const SRC_ASSET_EXTS = new Set([
-  ".css",
-  ".js",
-  ".svg",
-  ".mp4",
-  ".jpg",
-  ".png",
-  ".webm",
-  ".webp",
-  ".pdf",
-  ".ttf",
-  ".otf",
-]);
+import {
+  MEDIA_EXTENSIONS,
+  SRC_ASSET_EXTENSIONS,
+} from "./extension-whitelist.js";
 
 export async function watch() {
   const src = fromFileUrl(new URL("../src", import.meta.url));
@@ -47,7 +24,8 @@ export async function watch() {
     timer = undefined;
     const paths = reduceEvents(events);
     const tasks = new Map();
-    for (const [path] of paths) {
+    for (const [path, evtKind] of paths) {
+      if (evtKind !== "create" && evtKind !== "modify") continue;
       const kind = classifyPath(path);
       if (kind === "PAGE_HTML") {
         tasks.set(`page:${path}`, () => renderPage(path));
@@ -102,11 +80,11 @@ export function classifyPath(path) {
   if (lower.includes("/media/")) {
     const ext = lower.slice(lower.lastIndexOf("."));
 
-    if (MEDIA_EXTS.has(ext)) return "ASSET";
+    if (MEDIA_EXTENSIONS.has(ext)) return "ASSET";
   }
   if (lower.includes("/src/")) {
     const ext = lower.slice(lower.lastIndexOf("."));
-    if (SRC_ASSET_EXTS.has(ext)) return "ASSET";
+    if (SRC_ASSET_EXTENSIONS.has(ext)) return "ASSET";
 
   }
   return null;


### PR DESCRIPTION
## Summary
- centralize asset extension whitelist
- copy assets in a worker pool and keep relative paths
- watch only create/modify events when copying assets

## Testing
- `deno test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_688e7e65256c83318d9a6abb7f76a34b