### PR TITLE
Improve build efficiency with dependency tracking and worker pool

### DIFF
--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -6,15 +6,24 @@
  * @param {object} links       - Parsed links.json object.
  * @param {URL} [root]         - Base directory for templates as a file URL.
  */
-export async function applyTemplates(doc, frontMatter, links, root = new URL("..", import.meta.url)) {
+import { fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
+
+export async function applyTemplates(
+  doc,
+  frontMatter,
+  links,
+  root = new URL("..", import.meta.url),
+) {
   const slots = ["head", "nav", "footer"];
   const templates = frontMatter.templates || {};
+  const used = [];
 
   for (const slot of slots) {
     const name = templates[slot];
     if (!name) continue;
 
     const moduleUrl = new URL(`templates/${slot}/${name}.js`, root);
+    used.push(fromFileUrl(moduleUrl));
     const module = await import(moduleUrl.href);
     if (typeof module.render !== "function") {
       throw new Error(`Template ${slot}/${name} does not export render()`);
@@ -41,5 +50,6 @@ export async function applyTemplates(doc, frontMatter, links, root = new URL("..
       body.innerHTML = body.innerHTML + html;
     }
   }
-}
 
+  return used;
+}

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -5,43 +5,9 @@ import {
 } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
 
-const MAX_WORKERS = navigator.hardwareConcurrency ?? 2;
-const queue = [];
-let active = 0;
-
-function runNext() {
-  if (active >= MAX_WORKERS) return;
-  const job = queue.shift();
-  if (!job) return;
-  active++;
-  copyOne(job.path)
-    .catch((err) => {
-      if (err instanceof Error) {
-        if (!err.message.includes(job.path)) {
-          err.message = `${job.path}: ${err.message}`;
-        }
-        console.error(err);
-      } else {
-        console.error(err);
-      }
-    })
-    .finally(() => {
-      active--;
-      job.resolve();
-      runNext();
-    });
-}
-
-export function copyAsset(path) {
+export async function copyAsset(path) {
   const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
-  if (!SRC_ASSET_EXTENSIONS.has(ext)) return Promise.resolve();
-  return new Promise((resolve) => {
-    queue.push({ path, resolve });
-    runNext();
-  });
-}
-
-async function copyOne(path) {
+  if (!SRC_ASSET_EXTENSIONS.has(ext)) return;
   const siteDir = await findSiteRoot(path);
   const rel = relative(siteDir, path).replace(/\\/g, "/");
   const configPath = join(siteDir, "config.json");

--- a/lib/inline-svg.js
+++ b/lib/inline-svg.js
@@ -4,9 +4,12 @@
  * @param {Document} doc - DOM document to mutate.
  * @param {URL} [root] - Base directory for locating src-svg/ folder.
  */
+import { fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
+
 export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
   const base = new URL("src-svg/", root);
   const nodes = doc.querySelectorAll("icon, logo");
+  const used = [];
   for (const node of nodes) {
     const src = node.getAttribute("src");
     if (!src) continue;
@@ -21,7 +24,8 @@ export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
       }
       throw err;
     }
+    used.push(fromFileUrl(fileUrl));
     node.outerHTML = svg;
   }
+  return used;
 }
-

--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -1,0 +1,28 @@
+export const pageDeps = new Map();
+
+export function recordPageDeps(pagePath, templates = [], svgs = []) {
+  pageDeps.set(pagePath, {
+    templates: new Set(templates),
+    svgs: new Set(svgs),
+  });
+}
+
+export function pagesUsingTemplate(templatePath) {
+  const out = [];
+  for (const [page, deps] of pageDeps) {
+    if (deps.templates.has(templatePath)) out.push(page);
+  }
+  return out;
+}
+
+export function pagesUsingSvg(svgPath) {
+  const out = [];
+  for (const [page, deps] of pageDeps) {
+    if (deps.svgs.has(svgPath)) out.push(page);
+  }
+  return out;
+}
+
+export function clearPageDeps() {
+  pageDeps.clear();
+}

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -9,6 +9,7 @@ import { parsePage } from "./parse-page.js";
 import { LinksManager } from "./links.js";
 import { applyTemplates } from "./apply-templates.js";
 import { inlineSvg } from "./inline-svg.js";
+import { recordPageDeps } from "./page-deps.js";
 
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {
@@ -33,7 +34,12 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const doc = parser.parseFromString(page.html, "text/html");
     if (!doc) throw new Error(`${path}: invalid HTML`);
 
-    await applyTemplates(doc, page.frontMatter, linksManager.data, root);
+    const templatesUsed = await applyTemplates(
+      doc,
+      page.frontMatter,
+      linksManager.data,
+      root,
+    );
 
     let head = doc.head;
     if (!head) {
@@ -71,13 +77,15 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       body.appendChild(script);
     }
 
-    await inlineSvg(doc, toFileUrl(siteDir + "/"));
+    const svgsUsed = await inlineSvg(doc, toFileUrl(siteDir + "/"));
 
     const outRel = rel.replace(/\\/g, "/").replace(/\.html?$/i, "") + ".html";
     const outPath = join(distant, outRel);
     await Deno.mkdir(dirname(outPath), { recursive: true });
     const htmlOut = "<!DOCTYPE html>\n" + doc.documentElement.outerHTML;
     await Deno.writeTextFile(outPath, htmlOut);
+
+    recordPageDeps(path, templatesUsed, svgsUsed);
 
     const fmtCmd = new Deno.Command(Deno.execPath(), {
       args: ["fmt", outPath],

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,13 +1,53 @@
 import { fromFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
-import { renderPage } from "./render-page.js";
-import { renderAllUsingSvg, renderAllUsingTemplate } from "./rebuild.js";
-import { copyAsset } from "./copy-asset.js";
+import { pagesUsingSvg, pagesUsingTemplate } from "./page-deps.js";
 import {
   MEDIA_EXTENSIONS,
   SRC_ASSET_EXTENSIONS,
 } from "./extension-whitelist.js";
 
-export async function watch() {
+function createPool(size) {
+  const workerUrl = new URL("./worker-task.js", import.meta.url);
+  const idle = [];
+  const queue = [];
+  const jobs = new Map();
+  let id = 0;
+
+  for (let i = 0; i < size; i++) {
+    const w = new Worker(workerUrl.href, { type: "module" });
+    w.onmessage = (e) => {
+      const job = jobs.get(e.data.id);
+      jobs.delete(e.data.id);
+      if (e.data.error) {
+        job.reject(new Error(e.data.error));
+      } else {
+        job.resolve();
+      }
+      idle.push(w);
+      runNext();
+    };
+    idle.push(w);
+  }
+
+  function runNext() {
+    if (queue.length === 0 || idle.length === 0) return;
+    const w = idle.pop();
+    const job = queue.shift();
+    jobs.set(job.data.id, job);
+    w.postMessage(job.data);
+  }
+
+  function push(task) {
+    return new Promise((resolve, reject) => {
+      const data = { ...task, id: ++id };
+      queue.push({ data, resolve, reject });
+      runNext();
+    });
+  }
+
+  return { push };
+}
+
+export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
   const src = fromFileUrl(new URL("../src", import.meta.url));
   const templates = fromFileUrl(new URL("../templates", import.meta.url));
 
@@ -18,6 +58,7 @@ export async function watch() {
 
   const queue = [];
   let timer;
+  const pool = createPool(workers);
 
   async function flush() {
     const events = queue.splice(0);
@@ -28,16 +69,20 @@ export async function watch() {
       if (evtKind !== "create" && evtKind !== "modify") continue;
       const kind = classifyPath(path);
       if (kind === "PAGE_HTML") {
-        tasks.set(`page:${path}`, () => renderPage(path));
+        tasks.set(`render:${path}`, { type: "render", path });
       } else if (kind === "TEMPLATE") {
-        tasks.set(`tpl:${path}`, () => renderAllUsingTemplate(path));
+        for (const page of pagesUsingTemplate(path)) {
+          tasks.set(`render:${page}`, { type: "render", path: page });
+        }
       } else if (kind === "SVG_INLINE") {
-        tasks.set(`svg:${path}`, () => renderAllUsingSvg(path));
+        for (const page of pagesUsingSvg(path)) {
+          tasks.set(`render:${page}`, { type: "render", path: page });
+        }
       } else if (kind === "ASSET") {
-        tasks.set(`asset:${path}`, () => copyAsset(path));
+        tasks.set(`asset:${path}`, { type: "asset", path });
       }
     }
-    await Promise.all([...tasks.values()].map((fn) => fn()));
+    await Promise.all([...tasks.values()].map((t) => pool.push(t)));
   }
 
   async function handle(w) {
@@ -85,7 +130,6 @@ export function classifyPath(path) {
   if (lower.includes("/src/")) {
     const ext = lower.slice(lower.lastIndexOf("."));
     if (SRC_ASSET_EXTENSIONS.has(ext)) return "ASSET";
-
   }
   return null;
 }

--- a/lib/worker-task.js
+++ b/lib/worker-task.js
@@ -1,0 +1,17 @@
+import { renderPage } from "./render-page.js";
+import { copyAsset } from "./copy-asset.js";
+
+self.onmessage = async (e) => {
+  const { id, type, path } = e.data;
+  try {
+    if (type === "render") await renderPage(path);
+    else if (type === "asset") await copyAsset(path);
+    self.postMessage({ id });
+  } catch (err) {
+    if (err instanceof Error) {
+      self.postMessage({ id, error: err.message });
+    } else {
+      self.postMessage({ id, error: String(err) });
+    }
+  }
+};

--- a/tests/apply-templates.test.js
+++ b/tests/apply-templates.test.js
@@ -1,8 +1,10 @@
 import { applyTemplates } from "../lib/apply-templates.js";
 
 function assertEquals(actual, expected) {
-  if (actual !== expected) {
-    throw new Error(`Assertion failed: expected ${expected}, got ${actual}`);
+  const da = JSON.stringify(actual);
+  const db = JSON.stringify(expected);
+  if (da !== db) {
+    throw new Error(`Assertion failed: expected ${db}, got ${da}`);
   }
 }
 
@@ -43,12 +45,21 @@ Deno.test("applyTemplates inserts rendered fragments", async () => {
   const links = { nav: [], footer: [] };
 
   const root = new URL("./", import.meta.url);
-  await applyTemplates(doc, frontMatter, links, root);
+  const used = await applyTemplates(doc, frontMatter, links, root);
 
   assertEquals(doc.head.innerHTML, "<title>Example</title>");
   assertEquals(
     doc.body.innerHTML,
     "<nav>nav</nav><main>hi</main><footer>foot</footer>",
   );
+  assertEquals(used.length, 3);
+  const endsWith = used.map((p) => p.slice(p.indexOf("templates")));
+  assertEquals(
+    endsWith.sort(),
+    [
+      "templates/footer/default.js",
+      "templates/head/default.js",
+      "templates/nav/default.js",
+    ].sort(),
+  );
 });
-

--- a/tests/render-page.test.js
+++ b/tests/render-page.test.js
@@ -1,4 +1,5 @@
 import { renderPage } from "../lib/render-page.js";
+import { clearPageDeps, pageDeps } from "../lib/page-deps.js";
 import { join, toFileUrl } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { DOMParser } from "jsr:@b-fuze/deno-dom@0.1.56";
 
@@ -12,6 +13,7 @@ function assertEquals(a, b) {
 }
 
 Deno.test("renderPage renders page and updates links", async () => {
+  clearPageDeps();
   const root = await Deno.makeTempDir();
   const rootUrl = toFileUrl(root + "/");
   const siteDir = join(root, "mysite");
@@ -84,4 +86,8 @@ Deno.test("renderPage renders page and updates links", async () => {
     label: "Home",
     topLevel: true,
   });
+
+  const deps = pageDeps.get(pagePath);
+  assertEquals(deps.templates.size, 3);
+  assert(deps.svgs.has(join(siteDir, "src-svg", "ui", "check.svg")));
 });


### PR DESCRIPTION
## Summary
- track templates and SVGs used per page and expose reverse lookup helpers
- rerender only pages affected by template or SVG changes
- run render and asset copy tasks in a worker pool defaulting to CPU cores

## Testing
- `deno test --allow-all --unsafely-ignore-certificate-errors=jsr.io,deno.land`


------
https://chatgpt.com/codex/tasks/task_e_688e80d1db9883319765560508ec3931