### PR TITLE
fix: handle missing document root in applyTemplates

### DIFF
--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -18,6 +18,11 @@ export async function applyTemplates(
   const templates = frontMatter.templates || {};
   const used = [];
 
+  if (!doc.documentElement) {
+    const htmlEl = doc.createElement("html");
+    doc.appendChild(htmlEl);
+  }
+
   for (const slot of slots) {
     const name = templates[slot];
     if (!name) continue;

--- a/tests/apply-templates.test.js
+++ b/tests/apply-templates.test.js
@@ -1,4 +1,5 @@
 import { applyTemplates } from "../lib/apply-templates.js";
+import { DOMParser } from "@b-fuze/deno-dom";
 
 function assertEquals(actual, expected) {
   const da = JSON.stringify(actual);
@@ -62,4 +63,17 @@ Deno.test("applyTemplates inserts rendered fragments", async () => {
       "templates/nav/default.js",
     ].sort(),
   );
+});
+
+Deno.test("applyTemplates handles document with no root element", async () => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("", "text/html");
+  const frontMatter = {
+    title: "Example",
+    templates: { head: "default" },
+  };
+  const links = { nav: [], footer: [] };
+  const root = new URL("./", import.meta.url);
+  await applyTemplates(doc, frontMatter, links, root);
+  assertEquals(doc.head.innerHTML, "<title>Example</title>");
 });


### PR DESCRIPTION
## Summary
- ensure applyTemplates creates a root `<html>` element when none exists
- test that templates can be applied to a document lacking a root element

## Testing
- `deno test --unsafely-ignore-certificate-errors -A --import-map=import_map.json`

------
https://chatgpt.com/codex/tasks/task_e_688f2947d0788331ba89aa9985bdabfd