### PR TITLE
fix: avoid duplicate css links

### DIFF
--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -44,13 +44,6 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const body = doc.body;
     if (!body) throw new Error(`${path}: Document missing <body>`);
 
-    for (const href of page.frontMatter.css ?? []) {
-      const link = doc.createElement("link");
-      link.setAttribute("rel", "stylesheet");
-      link.setAttribute("href", href);
-      head.appendChild(link);
-    }
-
     for (const src of page.scripts.modules ?? []) {
       const script = doc.createElement("script");
       script.setAttribute("type", "module");

--- a/tests/templates/head/default.js
+++ b/tests/templates/head/default.js
@@ -1,3 +1,6 @@
 export function render({ frontMatter }) {
-  return `<title>${frontMatter.title}</title>`;
+  const cssLinks = (frontMatter.css || [])
+    .map((href) => `<link rel="stylesheet" href="${href}">`)
+    .join("");
+  return `<title>${frontMatter.title}</title>${cssLinks}`;
 }


### PR DESCRIPTION
## Summary
- remove CSS link injection from `renderPage`
- handle stylesheet links inside head templates
- verify only one stylesheet tag is emitted

## Testing
- `deno test -A --import-map=import_map.json --cert /etc/ssl/certs/ca-certificates.crt`


------
https://chatgpt.com/codex/tasks/task_e_688f2d8e02d88331a7470af413c76fca