### PR TITLE
feat: add emoji logging helper

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -1,0 +1,40 @@
+const EMOJIS = {
+  success: "✅",
+  error: "❌",
+  warning: "⚠️",
+  info: "ℹ️",
+  debug: "🐛",
+  trace: "🔎",
+  create: "🆕",
+  update: "🔄",
+  delete: "🗑️",
+  start: "▶️",
+  stop: "⏹️",
+  retry: "🔁",
+  cancel: "🚫",
+  lock: "🔒",
+  unlock: "🔓",
+  test: "🧪",
+  build: "🛠️",
+  deploy: "🚀",
+  skip: "⏭️",
+  pending: "⏳",
+  aiworking: "✨",
+};
+
+export function getEmoji(action) {
+  if (!action) return "";
+  return EMOJIS[action.toLowerCase()] ?? "";
+}
+
+export function logWithEmoji(action, ...args) {
+  const emoji = getEmoji(action);
+  const message = args.join(" ");
+  if (emoji) {
+    console.log(`${emoji} ${message}`);
+  } else {
+    console.log(message);
+  }
+}
+
+export { EMOJIS };

--- a/lib/emoji.test.js
+++ b/lib/emoji.test.js
@@ -1,0 +1,25 @@
+import { getEmoji, logWithEmoji } from "./emoji.js";
+
+function assertEquals(actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`Assertion failed: expected ${expected}, got ${actual}`);
+  }
+}
+
+Deno.test("getEmoji returns correct emoji", () => {
+  assertEquals(getEmoji("success"), "✅");
+  assertEquals(getEmoji("unknown"), "");
+});
+
+Deno.test("logWithEmoji prefixes message with emoji", () => {
+  const logs = [];
+  const orig = console.log;
+  console.log = (msg) => logs.push(msg);
+  try {
+    logWithEmoji("error", "Something failed");
+  } finally {
+    console.log = orig;
+  }
+  assertEquals(logs.length, 1);
+  assertEquals(logs[0], "❌ Something failed");
+});


### PR DESCRIPTION
## Summary
- add `getEmoji` and `logWithEmoji` helper utilities
- test emoji lookup and logging behavior

## Testing
- `deno test --import-map=import_map.json --allow-read --allow-write --allow-net --allow-run --cert /etc/ssl/certs/ca-certificates.crt`


------
https://chatgpt.com/codex/tasks/task_e_688f33ad2e608331abb06cb357488cc0