### PR TITLE
feat: add emoji-based logging

### DIFF
--- a/lib/inline-svg.js
+++ b/lib/inline-svg.js
@@ -5,6 +5,7 @@
  * @param {URL} [root] - Base directory for locating src-svg/ folder.
  */
 import { fromFileUrl } from "@std/path";
+import { getEmoji } from "./emoji.js";
 
 export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
   const base = new URL("src-svg/", root);
@@ -19,7 +20,9 @@ export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
       svg = await Deno.readTextFile(fileUrl);
     } catch (err) {
       if (err instanceof Deno.errors.NotFound) {
-        console.error(`Missing SVG: ${fileUrl.pathname}`);
+        console.error(
+          `${getEmoji("error")} Missing SVG: ${fileUrl.pathname}`,
+        );
         continue;
       }
       throw err;

--- a/lib/parse-page.js
+++ b/lib/parse-page.js
@@ -1,4 +1,5 @@
 import { parse as parseToml } from "@std/toml";
+import { getEmoji } from "./emoji.js";
 
 const TOP_LEVEL_KEYS = [
   "title",
@@ -54,7 +55,9 @@ export async function parsePage(path) {
 function validateFrontMatter(fm, path) {
   for (const key of Object.keys(fm)) {
     if (!TOP_LEVEL_KEYS.includes(key)) {
-      console.warn(`${path}: unknown front-matter key \"${key}\"`);
+      console.warn(
+        `${getEmoji("warning")} ${path}: unknown front-matter key \"${key}\"`,
+      );
     }
   }
 
@@ -76,7 +79,9 @@ function validateFrontMatter(fm, path) {
   }
   for (const key of Object.keys(templates)) {
     if (!TEMPLATE_KEYS.includes(key)) {
-      console.warn(`${path}: unknown \"templates.${key}\" key`);
+      console.warn(
+        `${getEmoji("warning")} ${path}: unknown \"templates.${key}\" key`,
+      );
     }
   }
   if (typeof templates.head !== "string") {
@@ -98,7 +103,9 @@ function validateFrontMatter(fm, path) {
     }
     for (const key of Object.keys(scripts)) {
       if (!SCRIPT_KEYS.includes(key)) {
-        console.warn(`${path}: unknown \"scripts.${key}\" key`);
+        console.warn(
+          `${getEmoji("warning")} ${path}: unknown \"scripts.${key}\" key`,
+        );
       }
     }
     if (scripts.modules !== undefined) {
@@ -130,7 +137,9 @@ function validateFrontMatter(fm, path) {
     }
     for (const key of Object.keys(links)) {
       if (!LINK_SECTIONS.includes(key)) {
-        console.warn(`${path}: unknown \"links.${key}\" key`);
+        console.warn(
+          `${getEmoji("warning")} ${path}: unknown \"links.${key}\" key`,
+        );
       }
     }
 
@@ -141,7 +150,9 @@ function validateFrontMatter(fm, path) {
       }
       for (const key of Object.keys(nav)) {
         if (!NAV_LINK_KEYS.includes(key)) {
-          console.warn(`${path}: unknown \"links.nav.${key}\" key`);
+          console.warn(
+            `${getEmoji("warning")} ${path}: unknown \"links.nav.${key}\" key`,
+          );
         }
       }
       if (nav.topLevel !== undefined && typeof nav.topLevel !== "boolean") {
@@ -162,7 +173,9 @@ function validateFrontMatter(fm, path) {
       }
       for (const key of Object.keys(footer)) {
         if (!FOOTER_LINK_KEYS.includes(key)) {
-          console.warn(`${path}: unknown \"links.footer.${key}\" key`);
+          console.warn(
+            `${getEmoji("warning")} ${path}: unknown \"links.footer.${key}\" key`,
+          );
         }
       }
       if (footer.column !== undefined && typeof footer.column !== "string") {

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -5,6 +5,7 @@ import { LinksManager } from "./links.js";
 import { applyTemplates } from "./apply-templates.js";
 import { inlineSvg } from "./inline-svg.js";
 import { recordPageDeps } from "./page-deps.js";
+import { getEmoji } from "./emoji.js";
 
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {
@@ -91,10 +92,8 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       if (!err.message.includes(path)) {
         err.message = `${path}: ${err.message}`;
       }
-      console.error(err);
-    } else {
-      console.error(err);
     }
+    console.error(getEmoji("error"), err);
   }
 }
 

--- a/scripts/ensure-distant-dirs.js
+++ b/scripts/ensure-distant-dirs.js
@@ -6,6 +6,7 @@ import {
   normalize,
   resolve,
 } from "@std/path";
+import { logWithEmoji, getEmoji } from "../lib/emoji.js";
 
 /**
  * Walks each immediate subdirectory of `src/`, validates its `config.json`
@@ -20,11 +21,11 @@ async function main() {
   try {
     for await (const entry of Deno.readDir(srcDir)) {
       entries.push(entry);
-      console.log(`✅ DIR -- ${entry.name}`);
+      logWithEmoji("success", `DIR -- ${entry.name}`);
     }
   } catch (err) {
     if (err instanceof Deno.errors.NotFound) {
-      console.warn("No src directory found.");
+      console.warn(`${getEmoji("warning")} No src directory found.`);
       return;
     }
     throw err;
@@ -32,7 +33,7 @@ async function main() {
 
   const siteDirs = entries.filter((e) => e.isDirectory);
   if (siteDirs.length === 0) {
-    console.log("No site directories found in src.");
+    logWithEmoji("info", "No site directories found in src.");
     return;
   }
 
@@ -45,9 +46,11 @@ async function main() {
     try {
       const text = await Deno.readTextFile(configPath);
       config = JSON.parse(text);
-      console.log(`✅ CONFIG -- ${dirent.name} `);
+      logWithEmoji("success", `CONFIG -- ${dirent.name} `);
     } catch (err) {
-      console.warn(`❌ Skipping ${dirent.name}: cannot read config.json`);
+      console.warn(
+        `${getEmoji("error")} Skipping ${dirent.name}: cannot read config.json`,
+      );
       continue;
     }
 
@@ -99,7 +102,7 @@ function validateConfig(config, schema) {
 
 if (import.meta.main) {
   main().catch((err) => {
-    console.error(err);
+    console.error(getEmoji("error"), err);
     Deno.exit(1);
   });
 }


### PR DESCRIPTION
## Summary
- enhance script logging with emoji prefixes
- add warning emojis to parsePage validation
- decorate SVG and render errors with emojis

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688f3626facc8331895ae119ffe5da1e