### PR TITLE
docs: add missing jsdoc to scripts

### DIFF
--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -8,6 +8,15 @@
  */
 import { fromFileUrl } from "@std/path";
 
+/**
+ * Resolve template names from front matter and inject rendered HTML.
+ *
+ * @param {Document} doc       DOM document to mutate.
+ * @param {object} frontMatter Parsed front-matter object.
+ * @param {object} links       Parsed links.json object.
+ * @param {URL} [root]         Base directory for templates as a file URL.
+ * @returns {Promise<string[]>} Paths of templates used during rendering.
+ */
 export async function applyTemplates(
   doc,
   frontMatter,

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -1,6 +1,15 @@
 import { dirname, join, relative } from "@std/path";
 import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
 
+/**
+ * Copy an asset from the source tree to its distant output directory.
+ *
+ * Only files with extensions whitelisted in `SRC_ASSET_EXTENSIONS` are
+ * processed.
+ *
+ * @param {string} path Absolute path to the asset on disk.
+ * @returns {Promise<void>} Resolves when the asset has been copied.
+ */
 export async function copyAsset(path) {
   const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
   if (!SRC_ASSET_EXTENSIONS.has(ext)) return;
@@ -15,6 +24,12 @@ export async function copyAsset(path) {
   await Deno.copyFile(path, outPath);
 }
 
+/**
+ * Walk up the directory tree looking for a `config.json` file.
+ *
+ * @param {string} filePath Path of the file whose site root is required.
+ * @returns {Promise<string>} Directory containing the `config.json` file.
+ */
 async function findSiteRoot(filePath) {
   let dir = dirname(filePath);
   while (true) {

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -1,3 +1,7 @@
+/**
+ * Mapping of action names to emoji characters.
+ * @type {Record<string, string>}
+ */
 const EMOJIS = {
   success: "✅",
   error: "❌",
@@ -22,11 +26,24 @@ const EMOJIS = {
   aiworking: "✨",
 };
 
+/**
+ * Retrieve the emoji for a given action string.
+ *
+ * @param {string} [action] Action name such as "success" or "error".
+ * @returns {string} Emoji character or empty string if unknown.
+ */
 export function getEmoji(action) {
   if (!action) return "";
   return EMOJIS[action.toLowerCase()] ?? "";
 }
 
+/**
+ * Log a message to the console prefixed with the emoji for an action.
+ *
+ * @param {string} action Action name determining the emoji.
+ * @param {...unknown} args Additional values to log.
+ * @returns {void}
+ */
 export function logWithEmoji(action, ...args) {
   const emoji = getEmoji(action);
   const message = args.join(" ");

--- a/lib/extension-whitelist.js
+++ b/lib/extension-whitelist.js
@@ -1,3 +1,7 @@
+/**
+ * Lists of allowed file extensions grouped by asset type.
+ * @type {{styles: string[], scripts: string[], images: string[], video: string[], documents: string[], fonts: string[]}}
+ */
 export const EXT_WHITELIST = {
   styles: [".css"],
   scripts: [".js"],
@@ -7,12 +11,31 @@ export const EXT_WHITELIST = {
   fonts: [".ttf", ".otf"],
 };
 
+/**
+ * Set of media file extensions (images, video, documents, fonts).
+ * @type {Set<string>}
+ */
 export const MEDIA_EXTENSIONS = new Set(
-  [...EXT_WHITELIST.images, ...EXT_WHITELIST.video, ...EXT_WHITELIST.documents, ...EXT_WHITELIST.fonts].map((e) => e.toLowerCase()),
+  [
+    ...EXT_WHITELIST.images,
+    ...EXT_WHITELIST.video,
+    ...EXT_WHITELIST.documents,
+    ...EXT_WHITELIST.fonts,
+  ].map((e) => e.toLowerCase()),
 );
 
+/**
+ * Set of all source asset extensions that should be copied to the distant directory.
+ * @type {Set<string>}
+ */
 export const SRC_ASSET_EXTENSIONS = new Set(
-  [...EXT_WHITELIST.styles, ...EXT_WHITELIST.scripts, ...MEDIA_EXTENSIONS].map((e) => e.toLowerCase()),
+  [...EXT_WHITELIST.styles, ...EXT_WHITELIST.scripts, ...MEDIA_EXTENSIONS].map((
+    e,
+  ) => e.toLowerCase()),
 );
 
+/**
+ * All extensions handled by the build system.
+ * @type {Set<string>}
+ */
 export const ALL_EXTENSIONS = SRC_ASSET_EXTENSIONS;

--- a/lib/inline-svg.js
+++ b/lib/inline-svg.js
@@ -1,12 +1,13 @@
-/**
- * Replace <icon> and <logo> elements with inline SVG content.
- *
- * @param {Document} doc - DOM document to mutate.
- * @param {URL} [root] - Base directory for locating src-svg/ folder.
- */
 import { fromFileUrl } from "@std/path";
 import { getEmoji } from "./emoji.js";
 
+/**
+ * Replace `<icon>` and `<logo>` elements with inline SVG content.
+ *
+ * @param {Document} doc DOM document to mutate.
+ * @param {URL} [root] Base directory for locating the `src-svg/` folder.
+ * @returns {Promise<string[]>} Paths of SVG files inlined into the document.
+ */
 export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
   const base = new URL("src-svg/", root);
   const nodes = doc.querySelectorAll("icon, logo");

--- a/lib/links.js
+++ b/lib/links.js
@@ -1,10 +1,20 @@
+/**
+ * Manage the global `links.json` navigation file for a site.
+ */
 export class LinksManager {
+  /**
+   * @param {string} path Path to the `links.json` file.
+   */
   constructor(path) {
     this.path = path;
     this.data = { nav: [], footer: [] };
     this._original = "";
   }
 
+  /**
+   * Load the existing `links.json` file from disk, if present.
+   * @returns {Promise<void>}
+   */
   async load() {
     try {
       const text = await Deno.readTextFile(this.path);
@@ -21,6 +31,13 @@ export class LinksManager {
     }
   }
 
+  /**
+   * Merge link information extracted from a page into the global collection.
+   *
+   * @param {string} href URL of the page being processed.
+   * @param {{nav?: object, footer?: object}} pageLinks Links defined in the page front-matter.
+   * @returns {boolean} Whether the collection was modified.
+   */
   merge(href, pageLinks) {
     let changed = false;
     if (pageLinks.nav) {
@@ -61,6 +78,10 @@ export class LinksManager {
     return changed;
   }
 
+  /**
+   * Persist changes to `links.json` if the data has changed.
+   * @returns {Promise<void>}
+   */
   async save() {
     const json = JSON.stringify(this.data, null, 2) + "\n";
     if (json !== this._original) {
@@ -70,6 +91,13 @@ export class LinksManager {
   }
 }
 
+/**
+ * Compare two plain objects for shallow equality.
+ *
+ * @param {Record<string, unknown>} a First object to compare.
+ * @param {Record<string, unknown>} b Second object to compare.
+ * @returns {boolean} Whether the objects have the same keys and values.
+ */
 function objectsEqual(a, b) {
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);

--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -1,7 +1,19 @@
 import { getEmoji } from "./emoji.js";
 
+/**
+ * Map of page paths to their template and SVG dependencies.
+ * @type {Map<string, {templates: Set<string>, svgs: Set<string>}>}
+ */
 export const pageDeps = new Map();
 
+/**
+ * Record the dependencies used when rendering a page.
+ *
+ * @param {string} pagePath Path to the HTML page.
+ * @param {string[]} [templates] Template files referenced by the page.
+ * @param {string[]} [svgs] SVG files referenced by the page.
+ * @returns {void}
+ */
 export function recordPageDeps(pagePath, templates = [], svgs = []) {
   pageDeps.set(pagePath, {
     templates: new Set(templates),
@@ -9,6 +21,12 @@ export function recordPageDeps(pagePath, templates = [], svgs = []) {
   });
 }
 
+/**
+ * Get a list of pages that depend on a given template file.
+ *
+ * @param {string} templatePath Path to the template file.
+ * @returns {string[]} Array of page paths using the template.
+ */
 export function pagesUsingTemplate(templatePath) {
   const out = [];
   for (const [page, deps] of pageDeps) {
@@ -17,16 +35,26 @@ export function pagesUsingTemplate(templatePath) {
   return out;
 }
 
+/**
+ * Get a list of pages that inline a given SVG file.
+ *
+ * @param {string} svgPath Path to the SVG file.
+ * @returns {string[]} Array of page paths referencing the SVG.
+ */
 export function pagesUsingSvg(svgPath) {
   const out = [];
   const relativePath = svgPath.split("/src-svg/")[1] || svgPath;
-  console.log(`  ${getEmoji('trace')} looking for ${relativePath}...`);
+  console.log(`  ${getEmoji("trace")} looking for ${relativePath}...`);
   for (const [page, deps] of pageDeps) {
     if (deps.svgs.has(svgPath)) out.push(page);
   }
   return out;
 }
 
+/**
+ * Clear all recorded page dependencies.
+ * @returns {void}
+ */
 export function clearPageDeps() {
   pageDeps.clear();
 }

--- a/lib/parse-page.js
+++ b/lib/parse-page.js
@@ -52,6 +52,13 @@ export async function parsePage(path) {
   };
 }
 
+/**
+ * Validate the structure and values of the parsed front-matter object.
+ *
+ * @param {Record<string, unknown>} fm Parsed front-matter data.
+ * @param {string} path Path to the file being processed (for error messages).
+ * @returns {void}
+ */
 function validateFrontMatter(fm, path) {
   for (const key of Object.keys(fm)) {
     if (!TOP_LEVEL_KEYS.includes(key)) {
@@ -174,7 +181,9 @@ function validateFrontMatter(fm, path) {
       for (const key of Object.keys(footer)) {
         if (!FOOTER_LINK_KEYS.includes(key)) {
           console.warn(
-            `${getEmoji("warning")} ${path}: unknown \"links.footer.${key}\" key`,
+            `${
+              getEmoji("warning")
+            } ${path}: unknown \"links.footer.${key}\" key`,
           );
         }
       }

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -1,6 +1,11 @@
 import { walk } from "@std/fs/walk";
 import { renderPage } from "./render-page.js";
 
+/**
+ * Render every HTML page found under the `src/` directory.
+ *
+ * @returns {Promise<void>}
+ */
 export async function renderAllPages() {
   const root = new URL("../src", import.meta.url);
   try {
@@ -14,10 +19,22 @@ export async function renderAllPages() {
   }
 }
 
+/**
+ * Re-render all pages when a template changes.
+ *
+ * @param {string} _path Path to the updated template (unused).
+ * @returns {Promise<void>}
+ */
 export async function renderAllUsingTemplate(_path) {
   await renderAllPages();
 }
 
+/**
+ * Re-render all pages when a shared SVG changes.
+ *
+ * @param {string} _path Path to the updated SVG (unused).
+ * @returns {Promise<void>}
+ */
 export async function renderAllUsingSvg(_path) {
   await renderAllPages();
 }

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -7,6 +7,13 @@ import { inlineSvg } from "./inline-svg.js";
 import { recordPageDeps } from "./page-deps.js";
 import { getEmoji } from "./emoji.js";
 
+/**
+ * Render a single HTML source file to its output destination.
+ *
+ * @param {string} path Absolute path to the source HTML file.
+ * @param {URL} [root] Base URL used to resolve template locations.
+ * @returns {Promise<void>}
+ */
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {
     const page = await parsePage(path);
@@ -27,7 +34,7 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     }
 
     const parser = new DOMParser();
-    const docString = `<html><head></head><body>${page.html}</body></html>`
+    const docString = `<html><head></head><body>${page.html}</body></html>`;
     const doc = parser.parseFromString(docString, "text/html");
     if (!doc) throw new Error(`${path}: invalid HTML`);
 
@@ -100,6 +107,12 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
   }
 }
 
+/**
+ * Walk up the directory hierarchy to find the site root containing `config.json`.
+ *
+ * @param {string} filePath Starting path used to search for the site root.
+ * @returns {Promise<string>} Directory path containing `config.json`.
+ */
 async function findSiteRoot(filePath) {
   let dir = dirname(filePath);
   while (true) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -6,6 +6,12 @@ import {
 } from "./extension-whitelist.js";
 import { getEmoji } from "./emoji.js";
 
+/**
+ * Create a pool of worker threads to process tasks concurrently.
+ *
+ * @param {number} size Number of workers in the pool.
+ * @returns {{push: (task: object) => Promise<void>}} Pool interface.
+ */
 function createPool(size) {
   const workerUrl = new URL("./worker-task.js", import.meta.url);
   const idle = [];
@@ -48,6 +54,12 @@ function createPool(size) {
   return { push };
 }
 
+/**
+ * Watch the source and template directories for changes and trigger rebuilds.
+ *
+ * @param {number} [workers] Number of worker threads to use.
+ * @returns {Promise<void>}
+ */
 export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
   const src = fromFileUrl(new URL("../src", import.meta.url));
   const templates = fromFileUrl(new URL("../templates", import.meta.url));
@@ -72,16 +84,16 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
       if (kind === "PAGE_HTML") {
         tasks.set(`render:${path}`, { type: "render", path });
       } else if (kind === "TEMPLATE") {
-        console.log(`${getEmoji('update')} TEMPLATE UPDATED -- $ {path}`);
+        console.log(`${getEmoji("update")} TEMPLATE UPDATED -- $ {path}`);
         for (const page of pagesUsingTemplate(path)) {
           tasks.set(`render:${page}`, { type: "render", path: page });
         }
       } else if (kind === "SVG_INLINE") {
-        console.log(`${getEmoji('update')} SVG UPDATED -- ${path}`);
+        console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
         for (const page of pagesUsingSvg(path)) {
           tasks.set(`render:${page}`, { type: "render", path: page });
         }
-        console.log(`  ${getEmoji('update')} all page updated!`)
+        console.log(`  ${getEmoji("update")} all page updated!`);
       } else if (kind === "ASSET") {
         tasks.set(`asset:${path}`, { type: "asset", path });
       }
@@ -99,6 +111,12 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
   await Promise.all(watchers.map(handle));
 }
 
+/**
+ * Collapse multiple filesystem events into the most relevant ones.
+ *
+ * @param {Deno.FsEvent[]} events Events to reduce.
+ * @returns {Map<string, string>} Map of paths to final event kinds.
+ */
 export function reduceEvents(events) {
   const map = new Map();
   for (const evt of events) {
@@ -118,6 +136,12 @@ export function reduceEvents(events) {
   return map;
 }
 
+/**
+ * Classify a filesystem path to determine how it should be handled.
+ *
+ * @param {string} path Path to classify.
+ * @returns {"PAGE_HTML"|"TEMPLATE"|"SVG_INLINE"|"ASSET"|null} Classification result.
+ */
 export function classifyPath(path) {
   const p = path.replace(/\\/g, "/");
   const lower = p.toLowerCase();

--- a/lib/worker-task.js
+++ b/lib/worker-task.js
@@ -2,13 +2,23 @@ import { renderPage } from "./render-page.js";
 import { copyAsset } from "./copy-asset.js";
 import { getEmoji } from "./emoji.js";
 
+/**
+ * Handle tasks sent to the worker.
+ *
+ * @param {MessageEvent<{id:number,type:"render"|"asset",path:string}>} e Message event containing task details.
+ * @returns {Promise<void>}
+ */
 self.onmessage = async (e) => {
   const { id, type, path } = e.data;
   try {
     if (type === "render") await renderPage(path);
     else if (type === "asset") await copyAsset(path);
     self.postMessage({ id });
-    console.log(`${getEmoji('success')} ${type === "render" ? "Rendered":"Copied"} -- ${path}`);
+    console.log(
+      `${getEmoji("success")} ${
+        type === "render" ? "Rendered" : "Copied"
+      } -- ${path}`,
+    );
   } catch (err) {
     if (err instanceof Error) {
       self.postMessage({ id, error: err.message });
@@ -16,6 +26,10 @@ self.onmessage = async (e) => {
       self.postMessage({ id, error: String(err) });
     }
 
-    console.log(`${getEmoji('error')} Not ${type === "render" ? "Rendered":"Copied"} -- ${path}`);
+    console.log(
+      `${getEmoji("error")} Not ${
+        type === "render" ? "Rendered" : "Copied"
+      } -- ${path}`,
+    );
   }
 };

--- a/main.js
+++ b/main.js
@@ -4,6 +4,12 @@ import { parse } from "@std/flags";
 import { walk } from "@std/fs/walk";
 import { watch } from "./lib/watch.js";
 
+/**
+ * Create a worker pool for rendering tasks.
+ *
+ * @param {number} size Number of workers to spawn.
+ * @returns {{push: (task: object) => Promise<void>}} Pool interface.
+ */
 function createPool(size) {
   const workerUrl = new URL("./lib/worker-task.js", import.meta.url);
   const idle = [];
@@ -43,6 +49,12 @@ function createPool(size) {
   return { push };
 }
 
+/**
+ * Render all pages using a pool of workers.
+ *
+ * @param {number} workers Number of workers to use.
+ * @returns {Promise<void>}
+ */
 async function fullBuild(workers) {
   const root = new URL("./src", import.meta.url);
   const pool = createPool(workers);

--- a/scripts/ensure-distant-dirs.js
+++ b/scripts/ensure-distant-dirs.js
@@ -6,7 +6,7 @@ import {
   normalize,
   resolve,
 } from "@std/path";
-import { logWithEmoji, getEmoji } from "../lib/emoji.js";
+import { getEmoji, logWithEmoji } from "../lib/emoji.js";
 
 /**
  * Walks each immediate subdirectory of `src/`, validates its `config.json`
@@ -72,6 +72,13 @@ async function main() {
   }
 }
 
+/**
+ * Validate a site's configuration against the provided JSON schema.
+ *
+ * @param {Record<string, unknown>} config Parsed config object.
+ * @param {Record<string, unknown>} schema JSON schema to validate against.
+ * @returns {void}
+ */
 function validateConfig(config, schema) {
   const allowedProps = Object.keys(schema.properties ?? {});
   for (const key of Object.keys(config)) {


### PR DESCRIPTION
## Summary
- add JSDoc for worker pool and full build helpers
- document render and watch modules
- clarify config validation logic

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_688f49fe2d808331b8755d1fdaf6bbb4