### PR TITLE
Normalize SVG paths to ensure page rebuilds

### DIFF
--- a/lib/inline-svg.js
+++ b/lib/inline-svg.js
@@ -28,7 +28,14 @@ export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
       }
       throw err;
     }
-    used.push(fromFileUrl(fileUrl));
+    const filePath = fromFileUrl(fileUrl);
+    let realPath;
+    try {
+      realPath = await Deno.realPath(filePath);
+    } catch {
+      realPath = filePath;
+    }
+    used.push(realPath);
     node.outerHTML = svg;
   }
   return used;

--- a/lib/inline-svg.test.js
+++ b/lib/inline-svg.test.js
@@ -40,8 +40,11 @@ Deno.test("inlineSvg replaces node with SVG content", async () => {
   const el = new StubElement("icon", "check.svg");
   const doc = new StubDocument([el]);
   const rootUrl = new URL(root + "/", import.meta.url);
-  await inlineSvg(doc, rootUrl);
+  const used = await inlineSvg(doc, rootUrl);
   assertEquals(el.outerHTML, "<svg>ok</svg>");
+  const expected = await Deno.realPath(`${root}/src-svg/check.svg`);
+  assertEquals(used.length, 1);
+  assertEquals(used[0], expected);
 });
 
 Deno.test("inlineSvg logs error when SVG missing", async () => {
@@ -61,4 +64,3 @@ Deno.test("inlineSvg logs error when SVG missing", async () => {
   assertEquals(errors.length, 1);
   assertEquals(el.outerHTML, '<icon src="missing.svg" />');
 });
-

--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -43,10 +43,16 @@ export function pagesUsingTemplate(templatePath) {
  */
 export function pagesUsingSvg(svgPath) {
   const out = [];
-  const relativePath = svgPath.split("/src-svg/")[1] || svgPath;
+  let realPath;
+  try {
+    realPath = Deno.realPathSync(svgPath);
+  } catch {
+    realPath = svgPath;
+  }
+  const relativePath = realPath.split("/src-svg/")[1] || realPath;
   console.log(`  ${getEmoji("trace")} looking for ${relativePath}...`);
   for (const [page, deps] of pageDeps) {
-    if (deps.svgs.has(svgPath)) out.push(page);
+    if (deps.svgs.has(realPath)) out.push(page);
   }
   return out;
 }

--- a/lib/page-deps.test.js
+++ b/lib/page-deps.test.js
@@ -1,0 +1,15 @@
+import { clearPageDeps, pagesUsingSvg, recordPageDeps } from "./page-deps.js";
+import { join } from "@std/path";
+import { assertEquals } from "@std/assert";
+
+Deno.test("pagesUsingSvg resolves real paths", async () => {
+  clearPageDeps();
+  const root = await Deno.makeTempDir();
+  const svgDir = join(root, "src-svg");
+  await Deno.mkdir(svgDir, { recursive: true });
+  const svgPath = join(svgDir, "icon.svg");
+  await Deno.writeTextFile(svgPath, "<svg></svg>");
+  recordPageDeps(join(root, "index.html"), [], [svgPath]);
+  const nonCanonical = join(svgDir, "..", "src-svg", "icon.svg");
+  assertEquals(pagesUsingSvg(nonCanonical), [join(root, "index.html")]);
+});

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -90,10 +90,17 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
         }
       } else if (kind === "SVG_INLINE") {
         console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
-        for (const page of pagesUsingSvg(path)) {
-          tasks.set(`render:${page}`, { type: "render", path: page });
+        const pages = pagesUsingSvg(path);
+        if (pages.length === 0) {
+          console.log(`  ${getEmoji("trace")} no pages reference this SVG`);
+        } else {
+          for (const page of pages) {
+            tasks.set(`render:${page}`, { type: "render", path: page });
+          }
+          console.log(
+            `  ${getEmoji("update")} ${pages.length} page(s) updated`,
+          );
         }
-        console.log(`  ${getEmoji("update")} all page updated!`);
       } else if (kind === "ASSET") {
         tasks.set(`asset:${path}`, { type: "asset", path });
       }


### PR DESCRIPTION
## Summary
- Normalize inlined SVG paths to their real filesystem locations
- Resolve SVG paths when looking up dependent pages and improve watcher logging
- Add tests for SVG path resolution and used path reporting

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_688f4df6c434833197fef11bfe7414b9