### PR TITLE
feat: centralize page dependency tracking

### DIFF
--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -4,7 +4,6 @@ import { parsePage } from "./parse-page.js";
 import { LinksManager } from "./links.js";
 import { applyTemplates } from "./apply-templates.js";
 import { inlineSvg } from "./inline-svg.js";
-import { recordPageDeps } from "./page-deps.js";
 import { getEmoji } from "./emoji.js";
 
 /**
@@ -12,7 +11,7 @@ import { getEmoji } from "./emoji.js";
  *
  * @param {string} path Absolute path to the source HTML file.
  * @param {URL} [root] Base URL used to resolve template locations.
- * @returns {Promise<void>}
+ * @returns {Promise<{pagePath:string,templatesUsed:string[],svgsUsed:string[]}|undefined>}
  */
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {
@@ -84,8 +83,6 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const htmlOut = "<!DOCTYPE html>\n" + doc.documentElement.outerHTML;
     await Deno.writeTextFile(outPath, htmlOut);
 
-    recordPageDeps(path, templatesUsed, svgsUsed);
-
     const fmtCmd = new Deno.Command(Deno.execPath(), {
       args: ["fmt", outPath],
       stdout: "null",
@@ -97,6 +94,8 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
         `${outPath}: ${new TextDecoder().decode(stderr).trim()}`,
       );
     }
+
+    return { pagePath: path, templatesUsed, svgsUsed };
   } catch (err) {
     if (err instanceof Error) {
       if (!err.message.includes(path)) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,5 @@
 import { fromFileUrl } from "@std/path";
-import { pagesUsingSvg, pagesUsingTemplate } from "./page-deps.js";
+import { pagesUsingSvg, pagesUsingTemplate, recordPageDeps } from "./page-deps.js";
 import {
   MEDIA_EXTENSIONS,
   SRC_ASSET_EXTENSIONS,
@@ -28,6 +28,13 @@ function createPool(size) {
         job.reject(new Error(e.data.error));
       } else {
         job.resolve();
+      }
+      if (e.data.deps) {
+        recordPageDeps(
+          e.data.deps.pagePath,
+          e.data.deps.templatesUsed,
+          e.data.deps.svgsUsed,
+        );
       }
       idle.push(w);
       runNext();

--- a/lib/worker-task.js
+++ b/lib/worker-task.js
@@ -12,9 +12,13 @@ self.onmessage = async (e) => {
   const { id, type, path } = e.data;
   console.log(`${getEmoji("info")} Worker processing ${type}: ${path}`);
   try {
-    if (type === "render") await renderPage(path);
-    else if (type === "asset") await copyAsset(path);
-    self.postMessage({ id });
+    if (type === "render") {
+      const deps = await renderPage(path);
+      self.postMessage({ id, deps });
+    } else if (type === "asset") {
+      await copyAsset(path);
+      self.postMessage({ id });
+    }
     console.log(
       `${getEmoji("success")} ${
         type === "render" ? "Rendered" : "Copied"

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@
 import { parse } from "@std/flags";
 import { walk } from "@std/fs/walk";
 import { watch } from "./lib/watch.js";
+import { recordPageDeps } from "./lib/page-deps.js";
 
 /**
  * Create a worker pool for rendering tasks.
@@ -24,6 +25,13 @@ function createPool(size) {
       jobs.delete(e.data.id);
       if (e.data.error) job.reject(new Error(e.data.error));
       else job.resolve();
+      if (e.data.deps) {
+        recordPageDeps(
+          e.data.deps.pagePath,
+          e.data.deps.templatesUsed,
+          e.data.deps.svgsUsed,
+        );
+      }
       idle.push(w);
       runNext();
     };


### PR DESCRIPTION
## Summary
- return dependency info from `renderPage`
- collect worker dependency data in main thread during build and watch
- forward page dependency data from worker tasks

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688f5b68fe40833187fcf8da8890bfa3