### PR TITLE
Handle removal of source files during watch

### DIFF
--- a/docs/10-file-copy-rules.md
+++ b/docs/10-file-copy-rules.md
@@ -1,7 +1,7 @@
 # 10 – File-Copy Rules
 
 When a watched asset (CSS, JS, media) changes, Kobra Kreator **copies** it to
-the site’s `distantDirectory` instead of re-rendering the whole page.  
+the site’s `distantDirectory` instead of re-rendering the whole page.\
 This document spells out how paths are resolved, which extensions are handled,
 and what future enhancements are on the table.
 
@@ -10,16 +10,14 @@ and what future enhancements are on the table.
 ## 1. Core principle – “preserve the tree”
 
 ```
-
 /src/my-site.com/js/app.js      ──►  <distantDirectory>/js/app.js
 /src/my-site.com/media/images/logo.png
 ──►  <distantDirectory>/media/images/logo.png
-
 ```
 
-* **Relative path inside the site folder is kept verbatim.**  
+- **Relative path inside the site folder is kept verbatim.**\
   No minification, bundling, or renaming occurs in v1.
-* **Parent folders are created** in the output directory if missing.
+- **Parent folders are created** in the output directory if missing.
 
 > If two sites contain `js/app.js`, they won’t clash—each has its own
 > `distantDirectory`.
@@ -28,14 +26,14 @@ and what future enhancements are on the table.
 
 ## 2. Extension whitelist
 
-| Category | Extensions (case-insensitive) |
-| -------- | ----------------------------- |
-| Stylesheets | `.css` |
+| Category    | Extensions (case-insensitive)                                    |
+| ----------- | ---------------------------------------------------------------- |
+| Stylesheets | `.css`                                                           |
 | JavaScript  | `.js` <!-- TODO: add `.mjs`, `.cjs` if/when we support them. --> |
-| Images      | `.svg` (outside `src-svg/`), `.jpg`, `.png`, `.webp`, `.ico` |
-| Video       | `.mp4`, `.webm` |
-| Documents   | `.pdf` |
-| Fonts       | `.ttf`, `.otf` |
+| Images      | `.svg` (outside `src-svg/`), `.jpg`, `.png`, `.webp`, `.ico`     |
+| Video       | `.mp4`, `.webm`                                                  |
+| Documents   | `.pdf`                                                           |
+| Fonts       | `.ttf`, `.otf`                                                   |
 
 Anything **not** in this list is ignored by the copy routine; feel free to
 extend via a future config key.
@@ -44,10 +42,10 @@ extend via a future config key.
 
 ## 3. Copy triggers
 
-| Event source | Action |
-| ------------ | ------ |
-| **Modify** or **create** on a whitelisted file | Copy file to destination (overwrites if exists). |
-| **Remove** on a whitelisted file | *No action* in v1 (the stale file stays). <!-- TODO: implement `cleanOutput` option (see 07-config-schema). --> |
+| Event source                                   | Action                                               |
+| ---------------------------------------------- | ---------------------------------------------------- |
+| **Modify** or **create** on a whitelisted file | Copy file to destination (overwrites if exists).     |
+| **Remove** on a whitelisted file               | Delete file from destination to keep output in sync. |
 
 ---
 
@@ -56,22 +54,21 @@ extend via a future config key.
 Assets are copied via `Deno.copyFile()` which streams the file kernel-side—no
 RAM blow-ups for big videos.
 
-* Copy operations run in **worker pool** threads so page rendering isn’t blocked.
-* Failures (e.g. permissions) log an error and keep the watcher alive.
+- Copy operations run in **worker pool** threads so page rendering isn’t
+  blocked.
+- Failures (e.g. permissions) log an error and keep the watcher alive.
 
 ---
 
 ## 5. Future roadmap
 
-| Feature | Status | Notes |
-| ------- | ------ | ----- |
-| **Hash-based filenames** for cache busting | Planned | Tied to `hashAssets` in *07-config-schema*. |
-| **Clean up deleted assets** | Planned | Will respect upcoming `cleanOutput` flag. |
-| **Image optimisation (lossless)** | Investigate | Could be opt-in plugin. |
-| **Symlink instead of copy** on same volume | Evaluate | Saves disk during dev; risky for deployment. <!-- TODO: decide policy --> |
+| Feature                                    | Status      | Notes                                                                     |
+| ------------------------------------------ | ----------- | ------------------------------------------------------------------------- |
+| **Hash-based filenames** for cache busting | Planned     | Tied to `hashAssets` in _07-config-schema_.                               |
+| **Clean up deleted assets**                | Done        | Source removals delete corresponding output files.                        |
+| **Image optimisation (lossless)**          | Investigate | Could be opt-in plugin.                                                   |
+| **Symlink instead of copy** on same volume | Evaluate    | Saves disk during dev; risky for deployment. <!-- TODO: decide policy --> |
 
 ---
 
 ### Next → [11-dependencies](11-dependencies.md)
-
-

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -25,6 +25,32 @@ export async function copyAsset(path) {
 }
 
 /**
+ * Remove an asset from the distant output directory.
+ *
+ * Only files with extensions whitelisted in `SRC_ASSET_EXTENSIONS` are
+ * processed.
+ *
+ * @param {string} path Absolute path to the asset on disk.
+ * @returns {Promise<void>} Resolves when the asset has been removed.
+ */
+export async function removeAsset(path) {
+  const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+  if (!SRC_ASSET_EXTENSIONS.has(ext)) return;
+  const siteDir = await findSiteRoot(path);
+  const rel = relative(siteDir, path).replace(/\\/g, "/");
+  const configPath = join(siteDir, "config.json");
+  const configText = await Deno.readTextFile(configPath);
+  const config = JSON.parse(configText);
+  const distant = String(config.distantDirectory);
+  const outPath = join(distant, rel);
+  try {
+    await Deno.remove(outPath);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+}
+
+/**
  * Walk up the directory tree looking for a `config.json` file.
  *
  * @param {string} filePath Path of the file whose site root is required.

--- a/lib/copy-asset.test.js
+++ b/lib/copy-asset.test.js
@@ -1,4 +1,4 @@
-import { copyAsset } from "./copy-asset.js";
+import { copyAsset, removeAsset } from "./copy-asset.js";
 import { assert, assertEquals } from "@std/assert";
 import { dirname, join } from "@std/path";
 
@@ -29,6 +29,23 @@ Deno.test("copyAsset skips non-whitelisted extensions", async () => {
   await Deno.writeTextFile(srcFile, "hello");
   await copyAsset(srcFile);
   const outFile = join(distant, "notes.txt");
+  const exists = await fileExists(outFile);
+  assertEquals(exists, false);
+});
+
+Deno.test("removeAsset deletes destination file", async () => {
+  const root = await Deno.makeTempDir();
+  const distant = join(root, "dist");
+  await Deno.writeTextFile(
+    join(root, "config.json"),
+    JSON.stringify({ distantDirectory: distant }),
+  );
+  const srcFile = join(root, "js", "app.js");
+  await Deno.mkdir(dirname(srcFile), { recursive: true });
+  await Deno.writeTextFile(srcFile, "console.log('hi')");
+  await copyAsset(srcFile);
+  const outFile = join(distant, "js", "app.js");
+  await removeAsset(srcFile);
   const exists = await fileExists(outFile);
   assertEquals(exists, false);
 });

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -107,6 +107,28 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
 }
 
 /**
+ * Remove the rendered HTML output associated with a source file.
+ *
+ * @param {string} path Absolute path to the source HTML file.
+ * @returns {Promise<void>} Resolves when the output file has been removed.
+ */
+export async function removePage(path) {
+  const siteDir = await findSiteRoot(path);
+  const configPath = join(siteDir, "config.json");
+  const configText = await Deno.readTextFile(configPath);
+  const config = JSON.parse(configText);
+  const distant = String(config.distantDirectory);
+  const rel = relative(siteDir, path).replace(/\\/g, "/");
+  const outRel = rel.replace(/\\/g, "/").replace(/\.html?$/i, "") + ".html";
+  const outPath = join(distant, outRel);
+  try {
+    await Deno.remove(outPath);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+}
+
+/**
  * Walk up the directory hierarchy to find the site root containing `config.json`.
  *
  * @param {string} filePath Starting path used to search for the site root.

--- a/lib/render-page.test.js
+++ b/lib/render-page.test.js
@@ -1,0 +1,30 @@
+import { removePage } from "./render-page.js";
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+
+Deno.test("removePage deletes rendered file", async () => {
+  const root = await Deno.makeTempDir();
+  const distant = join(root, "dist");
+  await Deno.writeTextFile(
+    join(root, "config.json"),
+    JSON.stringify({ distantDirectory: distant }),
+  );
+  const srcFile = join(root, "index.html");
+  await Deno.writeTextFile(srcFile, "<h1>Test</h1>");
+  const outFile = join(distant, "index.html");
+  await Deno.mkdir(distant, { recursive: true });
+  await Deno.writeTextFile(outFile, "content");
+  await removePage(srcFile);
+  const exists = await fileExists(outFile);
+  assertEquals(exists, false);
+});
+
+async function fileExists(path) {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
+  }
+}

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,9 @@
 import { fromFileUrl } from "@std/path";
-import { pagesUsingSvg, pagesUsingTemplate, recordPageDeps } from "./page-deps.js";
+import {
+  pagesUsingSvg,
+  pagesUsingTemplate,
+  recordPageDeps,
+} from "./page-deps.js";
 import {
   MEDIA_EXTENSIONS,
   SRC_ASSET_EXTENSIONS,
@@ -86,30 +90,37 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
     const paths = reduceEvents(events);
     const tasks = new Map();
     for (const [path, evtKind] of paths) {
-      if (evtKind !== "create" && evtKind !== "modify") continue;
       const kind = classifyPath(path);
-      if (kind === "PAGE_HTML") {
-        tasks.set(`render:${path}`, { type: "render", path });
-      } else if (kind === "TEMPLATE") {
-        console.log(`${getEmoji("update")} TEMPLATE UPDATED -- $ {path}`);
-        for (const page of pagesUsingTemplate(path)) {
-          tasks.set(`render:${page}`, { type: "render", path: page });
-        }
-      } else if (kind === "SVG_INLINE") {
-        console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
-        const pages = pagesUsingSvg(path);
-        if (pages.length === 0) {
-          console.log(`  ${getEmoji("warning")} no pages reference this SVG`);
-        } else {
-          for (const page of pages) {
+      if (evtKind === "create" || evtKind === "modify") {
+        if (kind === "PAGE_HTML") {
+          tasks.set(`render:${path}`, { type: "render", path });
+        } else if (kind === "TEMPLATE") {
+          console.log(`${getEmoji("update")} TEMPLATE UPDATED -- $ {path}`);
+          for (const page of pagesUsingTemplate(path)) {
             tasks.set(`render:${page}`, { type: "render", path: page });
           }
-          console.log(
-            `  ${getEmoji("update")} ${pages.length} page(s) updated`,
-          );
+        } else if (kind === "SVG_INLINE") {
+          console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
+          const pages = pagesUsingSvg(path);
+          if (pages.length === 0) {
+            console.log(`  ${getEmoji("warning")} no pages reference this SVG`);
+          } else {
+            for (const page of pages) {
+              tasks.set(`render:${page}`, { type: "render", path: page });
+            }
+            console.log(
+              `  ${getEmoji("update")} ${pages.length} page(s) updated`,
+            );
+          }
+        } else if (kind === "ASSET") {
+          tasks.set(`asset:${path}`, { type: "asset", path });
         }
-      } else if (kind === "ASSET") {
-        tasks.set(`asset:${path}`, { type: "asset", path });
+      } else if (evtKind === "remove") {
+        if (kind === "PAGE_HTML") {
+          tasks.set(`remove:${path}`, { type: "remove-page", path });
+        } else if (kind === "ASSET") {
+          tasks.set(`remove:${path}`, { type: "remove-asset", path });
+        }
       }
     }
     await Promise.all([...tasks.values()].map((t) => pool.push(t)));

--- a/lib/watch.test.js
+++ b/lib/watch.test.js
@@ -14,6 +14,15 @@ function denoTest() {
     assertEquals(res.get("/a.html"), "create");
   });
 
+  Deno.test("reduceEvents handles remove", () => {
+    const events = [
+      { kind: "remove", paths: ["/a.html"] },
+      { kind: "remove", paths: ["/a.html"] },
+    ];
+    const res = reduceEvents(events);
+    assertEquals(res.get("/a.html"), "remove");
+  });
+
   Deno.test("classifyPath identifies types", () => {
     assertEquals(classifyPath("/src/site/page.html"), "PAGE_HTML");
     assertEquals(classifyPath("/templates/head.js"), "TEMPLATE");

--- a/lib/worker-task.js
+++ b/lib/worker-task.js
@@ -1,11 +1,11 @@
-import { renderPage } from "./render-page.js";
-import { copyAsset } from "./copy-asset.js";
+import { removePage, renderPage } from "./render-page.js";
+import { copyAsset, removeAsset } from "./copy-asset.js";
 import { getEmoji } from "./emoji.js";
 
 /**
  * Handle tasks sent to the worker.
  *
- * @param {MessageEvent<{id:number,type:"render"|"asset",path:string}>} e Message event containing task details.
+ * @param {MessageEvent<{id:number,type:"render"|"asset"|"remove-page"|"remove-asset",path:string}>} e Message event containing task details.
  * @returns {Promise<void>}
  */
 self.onmessage = async (e) => {
@@ -18,12 +18,19 @@ self.onmessage = async (e) => {
     } else if (type === "asset") {
       await copyAsset(path);
       self.postMessage({ id });
+    } else if (type === "remove-page") {
+      await removePage(path);
+      self.postMessage({ id });
+    } else if (type === "remove-asset") {
+      await removeAsset(path);
+      self.postMessage({ id });
     }
-    console.log(
-      `${getEmoji("success")} ${
-        type === "render" ? "Rendered" : "Copied"
-      } -- ${path}`,
-    );
+    const action = type === "render"
+      ? "Rendered"
+      : type === "asset"
+      ? "Copied"
+      : "Removed";
+    console.log(`${getEmoji("success")} ${action} -- ${path}`);
   } catch (err) {
     if (err instanceof Error) {
       self.postMessage({ id, error: err.message });
@@ -31,10 +38,11 @@ self.onmessage = async (e) => {
       self.postMessage({ id, error: String(err) });
     }
 
-    console.log(
-      `${getEmoji("error")} Not ${
-        type === "render" ? "Rendered" : "Copied"
-      } -- ${path}`,
-    );
+    const action = type === "render"
+      ? "Rendered"
+      : type === "asset"
+      ? "Copied"
+      : "Removed";
+    console.log(`${getEmoji("error")} Not ${action} -- ${path}`);
   }
 };


### PR DESCRIPTION
## Summary
- remove generated output when source pages or assets are deleted
- support new `remove-page`/`remove-asset` tasks in worker pool
- document watch and copy behaviour for deletions

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688f60bafda083319221d4309b916b24