### PR TITLE
Require .inline.js suffix and skip copying inline scripts

### DIFF
--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -11,6 +11,10 @@ import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
  * @returns {Promise<void>} Resolves when the asset has been copied.
  */
 export async function copyAsset(path) {
+  if (path.endsWith(".inline.js")) {
+    // Inline scripts are bundled directly into HTML and should not be copied.
+    return;
+  }
   const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
   if (!SRC_ASSET_EXTENSIONS.has(ext)) return;
   const siteDir = await findSiteRoot(path);

--- a/lib/extension-whitelist.js
+++ b/lib/extension-whitelist.js
@@ -4,6 +4,8 @@
  */
 export const EXT_WHITELIST = {
   styles: [".css"],
+  // Inline scripts use a `.inline.js` suffix and are intentionally omitted here
+  // so they are inlined rather than copied as separate assets.
   scripts: [".js"],
   images: [".svg", ".jpg", ".png", ".webp", ".ico"],
   video: [".mp4", ".webm"],

--- a/lib/parse-page.js
+++ b/lib/parse-page.js
@@ -134,6 +134,13 @@ function validateFrontMatter(fm, path) {
           `${path}: \"scripts.inline\" must be an array of strings`,
         );
       }
+      for (const file of scripts.inline) {
+        if (!file.endsWith(".inline.js")) {
+          throw new Error(
+            `${path}: \"scripts.inline\" entries must end with .inline.js`,
+          );
+        }
+      }
     }
   }
 

--- a/tests/inline-scripts.test.js
+++ b/tests/inline-scripts.test.js
@@ -1,0 +1,75 @@
+import { renderPage } from "../lib/render-page.js";
+import { copyAsset } from "../lib/copy-asset.js";
+import { join, toFileUrl } from "@std/path";
+import { DOMParser } from "@b-fuze/deno-dom";
+
+/**
+ * Simple assertion helper.
+ * @param {unknown} cond Condition expected to be truthy.
+ * @param {string} [msg] Optional assertion message.
+ */
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+
+/**
+ * Check whether a file exists on disk.
+ * @param {string} path Path to test.
+ * @returns {Promise<boolean>} True if the file exists.
+ */
+async function exists(path) {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
+  }
+}
+
+Deno.test("inline scripts are inlined and not copied", async () => {
+  const root = await Deno.makeTempDir();
+  const rootUrl = toFileUrl(root + "/");
+  const siteDir = join(root, "site");
+  const distDir = join(root, "dist");
+  await Deno.mkdir(siteDir, { recursive: true });
+  await Deno.mkdir(distDir, { recursive: true });
+
+  await Deno.writeTextFile(
+    join(siteDir, "config.json"),
+    JSON.stringify({ distantDirectory: distDir }),
+  );
+  const inlineFile = "test.inline.js";
+  await Deno.writeTextFile(
+    join(siteDir, inlineFile),
+    "console.log('inline');",
+  );
+
+  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "head", "default.js"),
+    "export function render() { return `<title>Inline</title>`; }",
+  );
+
+  const pagePath = join(siteDir, "index.html");
+  const page =
+    `title = "Inline"\n[scripts]\ninline = ["${inlineFile}"]\n[templates]\nhead = "default"\n#---#\n<body></body>`;
+  await Deno.writeTextFile(pagePath, page);
+
+  // Attempt to copy the inline script; this should be skipped.
+  await copyAsset(join(siteDir, inlineFile));
+
+  await renderPage(pagePath, rootUrl);
+
+  const distInline = join(distDir, inlineFile);
+  assert(!(await exists(distInline)), "inline script should not be copied");
+
+  const outHtml = await Deno.readTextFile(join(distDir, "index.html"));
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(outHtml, "text/html");
+  assert(doc);
+  const inlineScript = Array.from(doc.querySelectorAll("script")).find(
+    (s) => !s.getAttribute("src"),
+  );
+  assert(inlineScript?.textContent.includes("console.log"));
+});

--- a/tests/render-page.test.js
+++ b/tests/render-page.test.js
@@ -25,7 +25,10 @@ Deno.test("renderPage renders page and updates links", async () => {
     join(siteDir, "config.json"),
     JSON.stringify({ distantDirectory: distDir }),
   );
-  await Deno.writeTextFile(join(siteDir, "inline.js"), "console.log('hi');");
+  await Deno.writeTextFile(
+    join(siteDir, "inline.inline.js"),
+    "console.log('hi');",
+  );
   await Deno.mkdir(join(siteDir, "src-svg", "ui"), { recursive: true });
   await Deno.writeTextFile(
     join(siteDir, "src-svg", "ui", "check.svg"),
@@ -56,7 +59,7 @@ Deno.test("renderPage renders page and updates links", async () => {
   await Deno.mkdir(join(siteDir, "blog"), { recursive: true });
   const pagePath = join(siteDir, "blog", "index.html");
   const page =
-    `title = "Hello"\ncss = ["styles.css"]\n[scripts]\nmodules = ["/js/app.js"]\ninline = ["inline.js"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n[links.nav]\ntopLevel = true\nlabel = "Home"\n#---#\n<body><icon src="ui/check.svg"></icon></body>`;
+    `title = "Hello"\ncss = ["styles.css"]\n[scripts]\nmodules = ["/js/app.js"]\ninline = ["inline.inline.js"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n[links.nav]\ntopLevel = true\nlabel = "Home"\n#---#\n<body><icon src="ui/check.svg"></icon></body>`;
   await Deno.writeTextFile(pagePath, page);
 
   const deps = await renderPage(pagePath, rootUrl);


### PR DESCRIPTION
## Summary
- validate `scripts.inline` entries end with `.inline.js`
- skip copying `.inline.js` assets and document whitelist exclusion
- add regression test ensuring `.inline.js` scripts are inlined and not copied

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688f81d1546483319d01caec6eb9a307