### PR TITLE
Document inline JavaScript watch and copy rules

### DIFF
--- a/docs/09-watch-rules.md
+++ b/docs/09-watch-rules.md
@@ -53,11 +53,15 @@ We reduce _raw events_ to _logical events_ with two rules:
 | `.html`                                                                                 | `renderPage(path)`             |
 | `.js` **under `/templates/`**                                                           | `renderAllUsingTemplate(path)` |
 | `.svg` **under `src-svg/`**                                                             | `renderAllUsingSvg(path)`      |
+| `.inline.js`                                                                            | `renderAllUsingScript(path)`   |
 | `.css`, `.js` **under a site folder**                                                   | `copyAsset(path)`              |
 | Media files in `media/`<br>`(.svg\*, .mp4, .jpg, .png, .webm, .webp, .pdf, .ttf, .otf)` | `copyAsset(path)`              |
 
 \* SVG files **outside** `src-svg/` are treated as binary assets, **not**
 inlined.
+
+Inline script files (`.inline.js`) trigger `renderAllUsingScript` to re-render
+any pages that include them.
 
 <!-- TODO: confirm whether `.ico` should trigger copy or be ignored. Current spec lists it in watch list. -->
 
@@ -83,6 +87,7 @@ for (const batch of debounce(watchFs(["/src", "/templates"]))) {
         tasks.add(() => renderAllUsingTemplate(evt.path));
       }
       if (kind === "SVG_INLINE") tasks.add(() => renderAllUsingSvg(evt.path));
+      if (kind === "JS_INLINE") tasks.add(() => renderAllUsingScript(evt.path));
       if (kind === "ASSET") tasks.add(() => copyAsset(evt.path));
     }
   }

--- a/docs/10-file-copy-rules.md
+++ b/docs/10-file-copy-rules.md
@@ -38,6 +38,9 @@ and what future enhancements are on the table.
 Anything **not** in this list is ignored by the copy routine; feel free to
 extend via a future config key.
 
+Inline JavaScript (`.inline.js`) files are intentionally excluded—they are
+inlined into HTML pages instead of being copied.
+
 ---
 
 ## 3. Copy triggers


### PR DESCRIPTION
## Summary
- Describe how `.inline.js` files are handled in watch rules and pseudocode
- Note that `.inline.js` files are inlined into HTML and not copied

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688f877a2d4483318c82ab278a3cb7a8