### PR TITLE
feat: track inline script dependencies

### DIFF
--- a/docs/06-rendering-pipeline.md
+++ b/docs/06-rendering-pipeline.md
@@ -40,34 +40,36 @@ flowchart TD
 
 ### 2.1 Parse front‑matter & HTML
 
-* Use [`TOMLParser`](https://deno.land/std/toml) to convert the header into an
+- Use [`TOMLParser`](https://deno.land/std/toml) to convert the header into an
   object.
-* HTML section is loaded into [https://deno.land/x/deno\_dom](https://deno.land/x/deno_dom)’s `DOMParser` for
-  subsequent manipulations.
+- HTML section is loaded into
+  [https://deno.land/x/deno\_dom](https://deno.land/x/deno_dom)’s `DOMParser`
+  for subsequent manipulations.
 
 ### 2.2 Update `links.json`
 
-* If the page’s front‑matter contains **any** `links.*` keys, merge them into
+- If the page’s front‑matter contains **any** `links.*` keys, merge them into
   the site’s `links.json`.
-* **Deduplication** – Two identical `href`/`label` pairs are collapsed if from the same source file. Else an error is thrown.
->
-* The file is written back **only if** its in‑memory representation changed to
+- **Deduplication** – Two identical `href`/`label` pairs are collapsed if from
+  the same source file. Else an error is thrown.
+
+- The file is written back **only if** its in‑memory representation changed to
   avoid spurious disk writes.
 
 ### 2.3 Apply templates
 
-* Resolve file path: `templates/<slot>/<name>.js`.
-* Import (cached by Deno) and call `render({ frontMatter, links })`.
-* For *head*: returned HTML is **prepended** inside a fresh `<head>` element.
-* For *nav* / *footer*: returned fragment is inserted **before** the content and
+- Resolve file path: `templates/<slot>/<name>.js`.
+- Import (cached by Deno) and call `render({ frontMatter, links })`.
+- For _head_: returned HTML is **prepended** inside a fresh `<head>` element.
+- For _nav_ / _footer_: returned fragment is inserted **before** the content and
   **after** it respectively.
 
 ### 2.4 Inject styles & scripts
 
 1. **CSS list** – Each entry becomes `<link rel="stylesheet" href="…">` inside
    `<head>`.
-2. **Module scripts** – Output `<script type="module" src="…">` *before*
-   inline scripts.
+2. **Module scripts** – Output `<script type="module" src="…">` _before_ inline
+   scripts.
 3. **Inline scripts** – The referenced file’s text is wrapped in
    `<script>(/* … */)</script>` and placed just before `</body>`.
 
@@ -75,32 +77,35 @@ flowchart TD
 
 ### 2.5 Assemble & inline SVGs
 
-* Combine head, nav, page content, footer, scripts into a DOM tree.
-* Replace each `<icon>` / `<logo>` node with SVG markup pulled from
-  `src-svg/`.
-* Remove unused whitespace if `--minify` flag is passed. <!-- TODO: implement minify option -->
+- Combine head, nav, page content, footer, scripts into a DOM tree.
+- Replace each `<icon>` / `<logo>` node with SVG markup pulled from `src-svg/`.
+- Remove unused whitespace if `--minify` flag is passed.
+  <!-- TODO: implement minify option -->
 
 ### 2.6 Write output
 
-* Compute destination: `<distantDirectory>/<relative/path/of/page>.html`.
-* Ensure folders exist (`Deno.mkdir({ recursive: true })`).
-* Write file with UTF‑8 encoding.
+- Compute destination: `<distantDirectory>/<relative/path/of/page>.html`.
+- Ensure folders exist (`Deno.mkdir({ recursive: true })`).
+- Write file with UTF‑8 encoding.
 
 ---
 
 ## 3. Dependency graph & smart invalidation
 
-To avoid re‑rendering *every* page on every change, Kobra Kreator maintains a
+To avoid re‑rendering _every_ page on every change, Kobra Kreator maintains a
 **dependency map** at runtime:
 
-| Dependency         | Recorded as                                |
-| ------------------ | ------------------------------------------ |
-| Page → template(s) | `pageDeps.templates = ["head/default", …]` |
-| Page → SVG(s) used | `pageDeps.svgs     = ["ui/check.svg", …]`  |
+| Dependency              | Recorded as                                   |
+| ----------------------- | --------------------------------------------- |
+| Page → template(s)      | `pageDeps.templates = ["head/default", …]`    |
+| Page → SVG(s) used      | `pageDeps.svgs     = ["ui/check.svg", …]`     |
+| Page → inline script(s) | `pageDeps.scripts  = ["inline.inline.js", …]` |
 
-* When a template changes, only pages whose `pageDeps.templates` contains that
+- When a template changes, only pages whose `pageDeps.templates` contains that
   template are re‑rendered.
-* When a file inside `src-svg/` changes, only pages referencing that SVG are
+- When a file inside `src-svg/` changes, only pages referencing that SVG are
+  re‑rendered.
+- When an inline script file changes, only pages referencing that script are
   re‑rendered.
 
 <!-- TODO: persist dependency map to disk to speed up cold start. -->
@@ -109,9 +114,10 @@ To avoid re‑rendering *every* page on every change, Kobra Kreator maintains a
 
 ## 4. Concurrency model
 
-* Rendering tasks are queued and run in **N worker threads** (default `N =
+- Rendering tasks are queued and run in **N worker threads** (default
+  `N =
   number of CPU cores`) using Deno’s worker API.
-* Each worker is **stateless**; the main thread coordinates disk writes to avoid
+- Each worker is **stateless**; the main thread coordinates disk writes to avoid
   race conditions on `links.json`.
 
 <!-- TODO: benchmark worker spawn cost vs. simple async pool. -->
@@ -133,13 +139,12 @@ available.
 
 ## 6. CLI flags (planned)
 
-* `--minify` – Collapse whitespace & inline `<style>`/`<script>` where possible.
-* `--verbose` – Extra timing info per stage.
-* `--workers=<n>` – Override default worker count.
+- `--minify` – Collapse whitespace & inline `<style>`/`<script>` where possible.
+- `--verbose` – Extra timing info per stage.
+- `--workers=<n>` – Override default worker count.
 
 <!-- TODO: update once the CLI is implemented in `main.js`. -->
 
 ---
 
 ### Next → [07-config-schema](07-config-schema.md)
-

--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -1,8 +1,8 @@
 import { getEmoji } from "./emoji.js";
 
 /**
- * Map of page paths to their template and SVG dependencies.
- * @type {Map<string, {templates: Set<string>, svgs: Set<string>}>}
+ * Map of page paths to their template, SVG, and inline script dependencies.
+ * @type {Map<string, {templates: Set<string>, svgs: Set<string>, scripts: Set<string>}>}
  */
 export const pageDeps = new Map();
 
@@ -12,12 +12,19 @@ export const pageDeps = new Map();
  * @param {string} pagePath Path to the HTML page.
  * @param {string[]} [templates] Template files referenced by the page.
  * @param {string[]} [svgs] SVG files referenced by the page.
+ * @param {string[]} [scripts] Inline script files referenced by the page.
  * @returns {void}
  */
-export function recordPageDeps(pagePath, templates = [], svgs = []) {
+export function recordPageDeps(
+  pagePath,
+  templates = [],
+  svgs = [],
+  scripts = [],
+) {
   pageDeps.set(pagePath, {
     templates: new Set(templates),
     svgs: new Set(svgs),
+    scripts: new Set(scripts),
   });
 }
 
@@ -53,6 +60,26 @@ export function pagesUsingSvg(svgPath) {
   console.log(`  ${getEmoji("trace")} looking for ${relativePath}...`);
   for (const [page, { svgs }] of pageDeps) {
     if (svgs.has(realPath)) out.push(page);
+  }
+  return out;
+}
+
+/**
+ * Get a list of pages that inline a given script file.
+ *
+ * @param {string} scriptPath Path to the inline script file.
+ * @returns {string[]} Array of page paths referencing the script.
+ */
+export function pagesUsingScript(scriptPath) {
+  const out = [];
+  let realPath;
+  try {
+    realPath = Deno.realPathSync(scriptPath);
+  } catch {
+    realPath = scriptPath;
+  }
+  for (const [page, { scripts }] of pageDeps) {
+    if (scripts.has(realPath)) out.push(page);
   }
   return out;
 }

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -11,7 +11,7 @@ import { getEmoji } from "./emoji.js";
  *
  * @param {string} path Absolute path to the source HTML file.
  * @param {URL} [root] Base URL used to resolve template locations.
- * @returns {Promise<{pagePath:string,templatesUsed:string[],svgsUsed:string[]}|undefined>}
+ * @returns {Promise<{pagePath:string,templatesUsed:string[],svgsUsed:string[],scriptsUsed:string[]}|undefined>}
  */
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {
@@ -61,15 +61,23 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       body.appendChild(script);
     }
 
+    const scriptsUsed = [];
     for (const file of page.scripts.inline ?? []) {
       const scriptPath = join(siteDir, file);
+      let realPath;
+      try {
+        realPath = await Deno.realPath(scriptPath);
+      } catch {
+        realPath = scriptPath;
+      }
       let content;
       try {
-        content = await Deno.readTextFile(scriptPath);
+        content = await Deno.readTextFile(realPath);
       } catch (err) {
-        if (err instanceof Error) err.message = `${scriptPath}: ${err.message}`;
+        if (err instanceof Error) err.message = `${realPath}: ${err.message}`;
         throw err;
       }
+      scriptsUsed.push(realPath);
       const script = doc.createElement("script");
       script.textContent = content;
       body.appendChild(script);
@@ -95,7 +103,7 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       );
     }
 
-    return { pagePath: path, templatesUsed, svgsUsed };
+    return { pagePath: path, templatesUsed, svgsUsed, scriptsUsed };
   } catch (err) {
     if (err instanceof Error) {
       if (!err.message.includes(path)) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,6 @@
 import { fromFileUrl } from "@std/path";
 import {
+  pagesUsingScript,
   pagesUsingSvg,
   pagesUsingTemplate,
   recordPageDeps,
@@ -38,6 +39,7 @@ function createPool(size) {
           e.data.deps.pagePath,
           e.data.deps.templatesUsed,
           e.data.deps.svgsUsed,
+          e.data.deps.scriptsUsed,
         );
       }
       idle.push(w);
@@ -98,6 +100,21 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
           console.log(`${getEmoji("update")} TEMPLATE UPDATED -- $ {path}`);
           for (const page of pagesUsingTemplate(path)) {
             tasks.set(`render:${page}`, { type: "render", path: page });
+          }
+        } else if (kind === "JS_INLINE") {
+          console.log(`${getEmoji("update")} INLINE SCRIPT UPDATED -- ${path}`);
+          const pages = pagesUsingScript(path);
+          if (pages.length === 0) {
+            console.log(
+              `  ${getEmoji("warning")} no pages reference this inline script`,
+            );
+          } else {
+            for (const page of pages) {
+              tasks.set(`render:${page}`, { type: "render", path: page });
+            }
+            console.log(
+              `  ${getEmoji("update")} ${pages.length} page(s) updated`,
+            );
           }
         } else if (kind === "SVG_INLINE") {
           console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
@@ -165,7 +182,7 @@ export function reduceEvents(events) {
  * Classify a filesystem path to determine how it should be handled.
  *
  * @param {string} path Path to classify.
- * @returns {"PAGE_HTML"|"TEMPLATE"|"SVG_INLINE"|"ASSET"|null} Classification result.
+ * @returns {"PAGE_HTML"|"TEMPLATE"|"SVG_INLINE"|"JS_INLINE"|"ASSET"|null} Classification result.
  */
 export function classifyPath(path) {
   const p = path.replace(/\\/g, "/");
@@ -175,6 +192,7 @@ export function classifyPath(path) {
   if (lower.includes("/src-svg/") && lower.endsWith(".svg")) {
     return "SVG_INLINE";
   }
+  if (lower.endsWith(".inline.js")) return "JS_INLINE";
   if (lower.includes("/media/")) {
     const ext = lower.slice(lower.lastIndexOf("."));
 

--- a/lib/watch.test.js
+++ b/lib/watch.test.js
@@ -27,6 +27,7 @@ function denoTest() {
     assertEquals(classifyPath("/src/site/page.html"), "PAGE_HTML");
     assertEquals(classifyPath("/templates/head.js"), "TEMPLATE");
     assertEquals(classifyPath("/src/site/src-svg/icon.svg"), "SVG_INLINE");
+    assertEquals(classifyPath("/src/site/foo.inline.js"), "JS_INLINE");
     assertEquals(classifyPath("/src/site/js/app.js"), "ASSET");
     assertEquals(classifyPath("/src/site/media/logo.png"), "ASSET");
   });

--- a/lib/worker-task.js
+++ b/lib/worker-task.js
@@ -1,6 +1,7 @@
 import { removePage, renderPage } from "./render-page.js";
 import { copyAsset, removeAsset } from "./copy-asset.js";
 import { getEmoji } from "./emoji.js";
+import { recordPageDeps } from "./page-deps.js";
 
 /**
  * Handle tasks sent to the worker.
@@ -14,6 +15,14 @@ self.onmessage = async (e) => {
   try {
     if (type === "render") {
       const deps = await renderPage(path);
+      if (deps) {
+        recordPageDeps(
+          deps.pagePath,
+          deps.templatesUsed,
+          deps.svgsUsed,
+          deps.scriptsUsed,
+        );
+      }
       self.postMessage({ id, deps });
     } else if (type === "asset") {
       await copyAsset(path);

--- a/main.js
+++ b/main.js
@@ -30,6 +30,7 @@ function createPool(size) {
           e.data.deps.pagePath,
           e.data.deps.templatesUsed,
           e.data.deps.svgsUsed,
+          e.data.deps.scriptsUsed,
         );
       }
       idle.push(w);

--- a/scripts/ensure-distant-dirs.js
+++ b/scripts/ensure-distant-dirs.js
@@ -47,7 +47,7 @@ async function main() {
       const text = await Deno.readTextFile(configPath);
       config = JSON.parse(text);
       logWithEmoji("success", `CONFIG -- ${dirent.name} `);
-    } catch (err) {
+    } catch (_err) {
       console.warn(
         `${getEmoji("error")} Skipping ${dirent.name}: cannot read config.json`,
       );

--- a/tests/render-page.test.js
+++ b/tests/render-page.test.js
@@ -29,6 +29,9 @@ Deno.test("renderPage renders page and updates links", async () => {
     join(siteDir, "inline.inline.js"),
     "console.log('hi');",
   );
+  const inlineScriptPath = await Deno.realPath(
+    join(siteDir, "inline.inline.js"),
+  );
   await Deno.mkdir(join(siteDir, "src-svg", "ui"), { recursive: true });
   await Deno.writeTextFile(
     join(siteDir, "src-svg", "ui", "check.svg"),
@@ -64,7 +67,12 @@ Deno.test("renderPage renders page and updates links", async () => {
 
   const deps = await renderPage(pagePath, rootUrl);
   if (deps) {
-    recordPageDeps(deps.pagePath, deps.templatesUsed, deps.svgsUsed);
+    recordPageDeps(
+      deps.pagePath,
+      deps.templatesUsed,
+      deps.svgsUsed,
+      deps.scriptsUsed,
+    );
   }
 
   const outPath = join(distDir, "blog", "index.html");
@@ -101,4 +109,6 @@ Deno.test("renderPage renders page and updates links", async () => {
   const depRec = pageDeps.get(pagePath);
   assertEquals(depRec.templates.size, 3);
   assert(depRec.svgs.has(join(siteDir, "src-svg", "ui", "check.svg")));
+  assert(deps?.scriptsUsed.includes(inlineScriptPath));
+  assert(depRec.scripts.has(inlineScriptPath));
 });


### PR DESCRIPTION
## Summary
- record inline script dependencies during page render
- watch for changes to inline script files and re-render affected pages
- document and test inline script dependency tracking

## Testing
- `deno lint`
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688f8906a4ec8331889fe270c687ac74