### PR TITLE
feat: add pretty urls option

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -22,7 +22,7 @@ implementation status.
 | `--minify` CLI flag                  | 🚧     | Collapse whitespace                    |
 | `--verbose` CLI flag                 | 🚧     | Extra timing info                      |
 | Config `baseUrl`                     | 🚧     | Inject canonical URLs                  |
-| Config `prettyUrls`                  | 🚧     | Omit `.html` in links                  |
+| Config `prettyUrls`                  | ✅     | Omit `.html` in links                  |
 | Config `hashAssets`                  | 🚧     | Content‑hashed asset filenames         |
 | Config `cleanOutput`                 | 🚧     | Remove stale files                     |
 | CLI `--outDir` override              | 🚧     | Temporarily change `distantDirectory`  |

--- a/docs/07-config-schema.md
+++ b/docs/07-config-schema.md
@@ -10,12 +10,13 @@ compiled site and (soon) several optional behaviours.
 
 ## 1. Current fields (v1)
 
-| Key                | Type   | Required | Description                                                                                                                                                                        |
-| ------------------ | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `distantDirectory` | string | **Yes**  | **Absolute** path where the rendered site will be written. Use forward slashes on macOS/Linux; Windows paths may use either `C:\\path` or `C:/path` and are normalised internally. |
+| Key                | Type    | Required | Description                                                                                                                                                                        |
+| ------------------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `distantDirectory` | string  | **Yes**  | **Absolute** path where the rendered site will be written. Use forward slashes on macOS/Linux; Windows paths may use either `C:\\path` or `C:/path` and are normalised internally. |
+| `prettyUrls`       | boolean | No       | If `true`, generator omits `.html` extensions in links and writes `index.html` files in matching folders.                                                                          |
 
-> If the path does **not** exist, Kobra Kreator creates it recursively.
-> If it **does** exist but is **not empty**, existing files are overwritten when
+> If the path does **not** exist, Kobra Kreator creates it recursively. If it
+> **does** exist but is **not empty**, existing files are overwritten when
 > pages/assets share the same relative path.
 
 ---
@@ -25,12 +26,11 @@ compiled site and (soon) several optional behaviours.
 These keys are **not yet implemented** but are listed here so integrators can
 begin planning. They will be added through minor/major version bumps.
 
-| Key           | Type    | Default | Purpose                                                                                                                                                  |
-| ------------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `baseUrl`     | string  | `"/"`   | Public URL prefix injected into templates for canonical links, OG tags, etc. <!-- TODO: confirm need & exact semantics. -->                              |
-| `prettyUrls`  | boolean | `false` | If `true`, generator omits `.html` extension in your links (writes `about/index.html`). <!-- TODO: implement & document rewrite rule responsibility. --> |
-| `hashAssets`  | boolean | `false` | When enabled, CSS/JS filenames receive a content hash (e.g. `app.4f3d.css`) for cache busting. <!-- TODO: design hash strategy & manifest. -->           |
-| `cleanOutput` | boolean | `false` | Remove files in `distantDirectory` that no longer exist in source. Useful for CI. <!-- TODO: evaluate performance impact. -->                            |
+| Key           | Type    | Default | Purpose                                                                                                                                        |
+| ------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`     | string  | `"/"`   | Public URL prefix injected into templates for canonical links, OG tags, etc. <!-- TODO: confirm need & exact semantics. -->                    |
+| `hashAssets`  | boolean | `false` | When enabled, CSS/JS filenames receive a content hash (e.g. `app.4f3d.css`) for cache busting. <!-- TODO: design hash strategy & manifest. --> |
+| `cleanOutput` | boolean | `false` | Remove files in `distantDirectory` that no longer exist in source. Useful for CI. <!-- TODO: evaluate performance impact. -->                  |
 
 Feel free to open a GitHub discussion if you need additional knobs.
 
@@ -43,9 +43,11 @@ Feel free to open a GitHub discussion if you need additional knobs.
   // v1 – minimal
   "distantDirectory": "/var/www/my-domain.com",
 
-  // v2 – optional extras (ignored by current release)
-  "baseUrl": "https://my-domain.com/",
+  // v1 – optional extras
   "prettyUrls": true,
+
+  // v2 – planned extras (currently ignored)
+  "baseUrl": "https://my-domain.com/",
   "hashAssets": true,
   "cleanOutput": true
 }
@@ -57,7 +59,7 @@ Feel free to open a GitHub discussion if you need additional knobs.
 
 ## 4. JSON‑Schema draft (for editor validation)
 
-Below is a *draft* Draft‑07 JSON‑Schema. Save it as `schemas/config.schema.json`
+Below is a _draft_ Draft‑07 JSON‑Schema. Save it as `schemas/config.schema.json`
 so editors like VS Code can auto‑validate.
 
 ```json
@@ -66,14 +68,18 @@ so editors like VS Code can auto‑validate.
   "title": "Kobra Kreator – site config",
   "type": "object",
   "required": ["distantDirectory"],
-  "additionalProperties": false,  // set to true once optional fields are live
+  "additionalProperties": false, // set to true once optional fields are live
   "properties": {
     "distantDirectory": {
       "type": "string",
       "description": "Absolute output path",
-      "pattern": "^(?:[a-zA-Z]:\\\\|/)"  /* simplistic absolute-path regex */
+      "pattern": "^(?:[a-zA-Z]:\\\\|/)" /* simplistic absolute-path regex */
+    },
+    "prettyUrls": {
+      "type": "boolean",
+      "description": "Omit .html extensions in links and emit index.html"
     }
-    /* TODO: add baseUrl, prettyUrls, hashAssets, cleanOutput once supported */
+    /* TODO: add baseUrl, hashAssets, cleanOutput once supported */
   }
 }
 ```
@@ -94,4 +100,3 @@ We plan to add CLI flags such as `--outDir` to temporarily override
 ---
 
 ### Next → [08-links-schema](08-links-schema.md)
-

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -22,12 +22,13 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const configText = await Deno.readTextFile(configPath);
     const config = JSON.parse(configText);
     const distant = String(config.distantDirectory);
+    const pretty = Boolean(config.prettyUrls);
 
     const linksManager = new LinksManager(join(siteDir, "links.json"));
     await linksManager.load();
     const rel = relative(siteDir, path).replace(/\\/g, "/");
     if (Object.keys(page.links).length > 0) {
-      const href = "/" + rel;
+      const href = toHref(rel, pretty);
       const changed = linksManager.merge(href, page.links);
       if (changed) await linksManager.save();
     }
@@ -85,7 +86,7 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
 
     const svgsUsed = await inlineSvg(doc, toFileUrl(siteDir + "/"));
 
-    const outRel = rel.replace(/\\/g, "/").replace(/\.html?$/i, "") + ".html";
+    const outRel = toOutRel(rel, pretty);
     const outPath = join(distant, outRel);
     await Deno.mkdir(dirname(outPath), { recursive: true });
     const htmlOut = "<!DOCTYPE html>\n" + doc.documentElement.outerHTML;
@@ -127,13 +128,45 @@ export async function removePage(path) {
   const config = JSON.parse(configText);
   const distant = String(config.distantDirectory);
   const rel = relative(siteDir, path).replace(/\\/g, "/");
-  const outRel = rel.replace(/\\/g, "/").replace(/\.html?$/i, "") + ".html";
+  const outRel = toOutRel(rel, Boolean(config.prettyUrls));
   const outPath = join(distant, outRel);
   try {
     await Deno.remove(outPath);
   } catch (err) {
     if (!(err instanceof Deno.errors.NotFound)) throw err;
   }
+}
+
+/**
+ * Build the href used in `links.json` for a page.
+ *
+ * @param {string} rel Page path relative to the site root.
+ * @param {boolean} pretty Whether `.html` extensions should be omitted.
+ * @returns {string} Href beginning with a leading slash.
+ */
+function toHref(rel, pretty) {
+  const normalized = rel.replace(/\\/g, "/");
+  if (!pretty) return "/" + normalized;
+  return "/" +
+    normalized.replace(/index\.html?$/i, "").replace(/\.html?$/i, "/");
+}
+
+/**
+ * Determine output file path relative to the distant directory.
+ *
+ * @param {string} rel Page path relative to the site root.
+ * @param {boolean} pretty Whether to emit `index.html` files for pages.
+ * @returns {string} Relative output path within the distant directory.
+ */
+function toOutRel(rel, pretty) {
+  const normalized = rel.replace(/\\/g, "/");
+  if (pretty) {
+    if (/index\.html?$/i.test(normalized)) {
+      return normalized.replace(/\.html?$/i, ".html");
+    }
+    return normalized.replace(/\.html?$/i, "/index.html");
+  }
+  return normalized.replace(/\.html?$/i, "") + ".html";
 }
 
 /**

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -9,6 +9,10 @@
       "type": "string",
       "description": "Absolute output path",
       "pattern": "^(?:[a-zA-Z]:\\\\|/)"
+    },
+    "prettyUrls": {
+      "type": "boolean",
+      "description": "Omit .html extensions and emit index.html files"
     }
   }
 }

--- a/src/my-project/config.json
+++ b/src/my-project/config.json
@@ -1,0 +1,4 @@
+{
+  "distantDirectory": "/tmp/my-project",
+  "prettyUrls": true
+}

--- a/tests/pretty-urls.test.js
+++ b/tests/pretty-urls.test.js
@@ -1,0 +1,64 @@
+import { renderPage } from "../lib/render-page.js";
+import { join, toFileUrl } from "@std/path";
+
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+function assertEquals(a, b) {
+  const da = JSON.stringify(a);
+  const db = JSON.stringify(b);
+  if (da !== db) throw new Error(`Expected ${db}, got ${da}`);
+}
+
+Deno.test("renderPage supports prettyUrls", async () => {
+  const root = await Deno.makeTempDir();
+  const rootUrl = toFileUrl(root + "/");
+  const siteDir = join(root, "mysite");
+  const distDir = join(root, "dist");
+  await Deno.mkdir(siteDir, { recursive: true });
+  await Deno.mkdir(distDir, { recursive: true });
+
+  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "head", "default.js"),
+    "export function render() { return `<title></title>`; }",
+  );
+  await Deno.writeTextFile(
+    join(root, "templates", "nav", "default.js"),
+    "export function render() { return ``; }",
+  );
+  await Deno.writeTextFile(
+    join(root, "templates", "footer", "default.js"),
+    "export function render() { return ``; }",
+  );
+
+  await Deno.writeTextFile(
+    join(siteDir, "config.json"),
+    JSON.stringify({ distantDirectory: distDir, prettyUrls: true }),
+  );
+
+  const indexPath = join(siteDir, "index.html");
+  const aboutPath = join(siteDir, "about.html");
+  await Deno.writeTextFile(
+    indexPath,
+    `title = "Home"\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n[links.nav]\nlabel = "Home"\ntopLevel = true\n#---#\n<body></body>`,
+  );
+  await Deno.writeTextFile(
+    aboutPath,
+    `title = "About"\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n[links.nav]\nlabel = "About"\n#---#\n<body></body>`,
+  );
+
+  await renderPage(indexPath, rootUrl);
+  await renderPage(aboutPath, rootUrl);
+
+  const aboutOut = join(distDir, "about", "index.html");
+  await Deno.readTextFile(aboutOut);
+
+  const links = JSON.parse(
+    await Deno.readTextFile(join(siteDir, "links.json")),
+  );
+  assertEquals(links.nav[0], { href: "/", label: "Home", topLevel: true });
+  assertEquals(links.nav[1], { href: "/about/", label: "About" });
+});


### PR DESCRIPTION
## Summary
- document and enable `prettyUrls` in config schema
- generate extensionless links and nested index.html when `prettyUrls` is set
- cover `prettyUrls` behavior with dedicated tests

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_688f9a6cf024833183a342c2c5a3d750