### PR TITLE
Add markdown parser tests and documentation

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,3 +1,9 @@
+/**
+ * Escape HTML special characters in a string.
+ *
+ * @param {string} text - Text to be escaped.
+ * @returns {string} Escaped HTML text.
+ */
 function escapeHTML(text) {
     return text
         .replace(/&/g, '&amp;')
@@ -7,18 +13,24 @@ function escapeHTML(text) {
         .replace(/'/g, '&#039;');
 }
 
+/**
+ * Convert inline Markdown elements within a string to HTML.
+ *
+ * @param {string} text - The text containing inline Markdown syntax.
+ * @returns {string} Text with inline Markdown converted to HTML.
+ */
 function processInlineElements(text) {
     // Code spans
     text = text.replace(/`([^\`]+)`/g, '<code>$1</code>');
-    
+
     // Bold
     text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
     text = text.replace(/__([^_]+)__/g, '<strong>$1</strong>');
-    
+
     // Italic
     text = text.replace(/\*([^*]+)\*/g, '<em>$1</em>');
     text = text.replace(/_([^_]+)_/g, '<em>$1</em>');
-    
+
     // Images
     text = text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">');
 
@@ -28,14 +40,20 @@ function processInlineElements(text) {
             ? `<a href="${url}" target="_blank" title="${title}">${text}</a>`
             : `<a href="${url}" target="_blank">${text}</a>`;
     });
-    
+
     // Footnotes
     text = text.replace(/\[\^([^\]]+)\](?!:)/g, '<sup><a href="#$1">$1</a></sup>');
-    
+
     return text;
 }
 
 // Simple Markdown parser and HTML generator
+/**
+ * Convert Markdown formatted text into HTML.
+ *
+ * @param {string} [markdown=""] - Markdown source to convert.
+ * @returns {string} Generated HTML output.
+ */
 export function markdownToHTML(markdown ="") {
     let html = '';
     const lines = markdown.split('\n');
@@ -50,6 +68,11 @@ export function markdownToHTML(markdown ="") {
     let inBlockquote = false;
     let blockquoteContent = '';
     
+    /**
+     * Close the currently open list element if one exists.
+     *
+     * @returns {void}
+     */
     function closeList() {
         if (inList) {
             html += `</${listType}>\n`;
@@ -58,7 +81,12 @@ export function markdownToHTML(markdown ="") {
             listIndent = 0;
         }
     }
-    
+
+    /**
+     * Close the currently open blockquote if one exists.
+     *
+     * @returns {void}
+     */
     function closeBlockquote() {
         if (inBlockquote) {
             html += `<blockquote>${processInlineElements(blockquoteContent.trim())}</blockquote>\n`;

--- a/lib/markdown.test.js
+++ b/lib/markdown.test.js
@@ -1,0 +1,23 @@
+import { markdownToHTML } from "./markdown.js";
+import { assertEquals } from "@std/assert";
+
+Deno.test("markdownToHTML converts basic elements", () => {
+    const input = "# Heading\n\nThis is **bold** and *italic* text.";
+    const expected = "<h1>Heading</h1>\n<p>This is <strong>bold</strong> and <em>italic</em> text.</p>\n";
+    assertEquals(markdownToHTML(input), expected);
+});
+
+Deno.test("markdownToHTML handles code blocks and escaping", () => {
+    const input = "```js\nconsole.log(\"<&>\");\n```\n";
+    const expected =
+        "<pre><code class=\"language-js\">console.log(&quot;&lt;&amp;&gt;&quot;);\n</code></pre>\n";
+    assertEquals(markdownToHTML(input), expected);
+});
+
+Deno.test("markdownToHTML processes tables", () => {
+    const input = "| a | b |\n| --- | ---: |\n| 1 | 2 |\n";
+    const expected =
+        "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td align=\"left\">1</td>\n<td align=\"right\">2</td>\n</tr>\n</tbody>\n</table>\n";
+    assertEquals(markdownToHTML(input), expected);
+});
+


### PR DESCRIPTION
## Summary
- document markdown parsing helpers
- add unit tests for markdownToHTML covering common syntax features

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_688fa410fbe483319626b8531e839842