### PR TITLE
feat: add markdown page support

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -15,9 +15,9 @@ implementation status.
 | Links.json navigation/footer         | ✅     | Auto‑merged from front‑matter          |
 | Dependency map for smart rebuilds    | ✅     | Tracks templates, SVGs & scripts       |
 | Worker thread rendering              | ✅     | `--workers` to override default        |
-| Markdown pages                       | ❌     | Currently HTML‑only. Next Priority     |
+| Markdown pages                       | ✅     | Write pages in Markdown (`.md`)        |
 | Plugin system                        | 🚧     | Allow custom build steps               |
-| Markdown → HTML converter            | 🚧     | Blog workflow support. Next Priority   |
+| Markdown → HTML converter            | ✅     | Built-in parser                        |
 | i18n routing                         | 🚧     | Compile language variants              |
 | `--minify` CLI flag                  | 🚧     | Collapse whitespace                    |
 | `--verbose` CLI flag                 | 🚧     | Extra timing info                      |

--- a/docs/04-front-matter.md
+++ b/docs/04-front-matter.md
@@ -1,8 +1,8 @@
 # 04 – Front‑Matter (TOML)
 
-Every HTML page starts with a **TOML block** delimited by the literal separator string `#---#`.
-The generator parses this front‑matter to decide which assets to attach, which
-templates to render, and how to update `links.json`.
+Every HTML page starts with a **TOML block** delimited by the literal separator
+string `#---#`. The generator parses this front‑matter to decide which assets to
+attach, which templates to render, and how to update `links.json`.
 
 ```html
 <title="My page">
@@ -18,21 +18,21 @@ templates to render, and how to update `links.json`.
 
 ## Field reference
 
-| Key                     | Type      | Required | Purpose / rules                                                                          |
-| ----------------------- | --------- | -------- | ---------------------------------------------------------------------------------------- |
-| `title`                 | string    | ✅        | Sets `<title>` content.                                                                  |
-| `description`           | string    | ⬜        | Injected as `<meta name="description">`.                                                 |
-| `css`                   | string\[] | ⬜        | Extra stylesheets. Relative to site root **or** absolute URL (CDN).                      |
-| `[templates].head`      | string    | ✅        | File name under `templates/head/` (without extension).                                   |
-| `[templates].nav`       | string    | ⬜        | File name under `templates/nav/`.                                                        |
-| `[templates].footer`    | string    | ⬜        | File name under `templates/footer/`.                                                     |
-| `[scripts].modules`     | string\[] | ⬜        | Added as `<script type="module" src="…">` *before* inline scripts.                       |
-| `[scripts].inline`      | string\[] | ⬜        | **Filename** to inline (**not** external URL)       |
-| `[links].nav.topLevel`  | bool      | ⬜        | If `true`, add to `links.json.nav` (top level).                                          |
-| `[links].nav.subLevel`  | string    | ⬜        | Name of submenu bucket to append under.                                                  |
-| `[links].nav.label`     | string    | ⬜        | Text shown in menu. Defaults to `title` if omitted. |
-| `[links].footer.column` | string    | ⬜        | Column bucket in `links.json.footer`.                                                    |
-| `[links].footer.label`  | string    | ⬜        | Link text in footer.                                                                     |
+| Key                     | Type      | Required | Purpose / rules                                                     |
+| ----------------------- | --------- | -------- | ------------------------------------------------------------------- |
+| `title`                 | string    | ✅       | Sets `<title>` content.                                             |
+| `description`           | string    | ⬜       | Injected as `<meta name="description">`.                            |
+| `css`                   | string\[] | ⬜       | Extra stylesheets. Relative to site root **or** absolute URL (CDN). |
+| `[templates].head`      | string    | ✅       | File name under `templates/head/` (without extension).              |
+| `[templates].nav`       | string    | ⬜       | File name under `templates/nav/`.                                   |
+| `[templates].footer`    | string    | ⬜       | File name under `templates/footer/`.                                |
+| `[scripts].modules`     | string\[] | ⬜       | Added as `<script type="module" src="…">` _before_ inline scripts.  |
+| `[scripts].inline`      | string\[] | ⬜       | **Filename** to inline (**not** external URL)                       |
+| `[links].nav.topLevel`  | bool      | ⬜       | If `true`, add to `links.json.nav` (top level).                     |
+| `[links].nav.subLevel`  | string    | ⬜       | Name of submenu bucket to append under.                             |
+| `[links].nav.label`     | string    | ⬜       | Text shown in menu. Defaults to `title` if omitted.                 |
+| `[links].footer.column` | string    | ⬜       | Column bucket in `links.json.footer`.                               |
+| `[links].footer.label`  | string    | ⬜       | Link text in footer.                                                |
 
 > **Validation** – Unknown keys log a warning but do **not** stop the build.
 > This keeps old pages working if new fields are added later.
@@ -42,7 +42,7 @@ templates to render, and how to update `links.json`.
 ## Minimal example
 
 ```toml
-# in /src/my-site.com/about.html
+# in /src/my-site.com/about.html (or about.md)
 
 title = "About us"
 
@@ -99,15 +99,15 @@ inline  = ["form.inline.js"]
 
 ## Gotchas & best practices
 
-* Keep file paths **relative** to the site root so sites remain portable.
-* Avoid leading `./` in `css` and `scripts` lists; just write `"styles.css"`.
-* Use **CDN URLs** only for assets you trust; the build does not verify HTTPS
+- Keep file paths **relative** to the site root so sites remain portable.
+- Avoid leading `./` in `css` and `scripts` lists; just write `"styles.css"`.
+- Use **CDN URLs** only for assets you trust; the build does not verify HTTPS
   certificates or sub‑resource integrity.
-* Remember that `scripts.inline` embeds the **file’s contents**, not a `<script src>` tag.
+- Remember that `scripts.inline` embeds the **file’s contents**, not a
+  `<script src>` tag.
 
   <!-- TODO: builder flag to switch between inline vs external link? -->
 
 ---
 
 ### Next → [05-templates-api](05-templates-api.md)
-

--- a/docs/06-rendering-pipeline.md
+++ b/docs/06-rendering-pipeline.md
@@ -84,7 +84,8 @@ flowchart TD
 
 ### 2.6 Write output
 
-- Compute destination: `<distantDirectory>/<relative/path/of/page>.html`.
+- Compute destination: `<distantDirectory>/<relative/path/of/page>.html`
+  (Markdown sources are converted to `.html`).
 - Ensure folders exist (`Deno.mkdir({ recursive: true })`).
 - Write file with UTF‑8 encoding.
 

--- a/docs/09-watch-rules.md
+++ b/docs/09-watch-rules.md
@@ -50,7 +50,7 @@ We reduce _raw events_ to _logical events_ with two rules:
 
 | Extension(s)                                                                            | Destination action             |
 | --------------------------------------------------------------------------------------- | ------------------------------ |
-| `.html`                                                                                 | `renderPage(path)`             |
+| `.html`, `.md`                                                                          | `renderPage(path)`             |
 | `.js` **under `/templates/`**                                                           | `renderAllUsingTemplate(path)` |
 | `.svg` **under `src-svg/`**                                                             | `renderAllUsingSvg(path)`      |
 | `.inline.js`                                                                            | `renderAllUsingScript(path)`   |

--- a/docs/11-dependencies.md
+++ b/docs/11-dependencies.md
@@ -1,7 +1,7 @@
 # 11 – Dependencies & Tooling
 
 Kobra Kreator intentionally keeps its dependency surface **thin**—just the Deno
-runtime plus a handful of third-party standard-library modules.  
+runtime plus a handful of third-party standard-library modules.\
 This document lists all required versions and explains how we pin / upgrade
 them.
 
@@ -9,12 +9,12 @@ them.
 
 ## 1. Deno runtime
 
-| Item | Value |
-| ---- | ----- |
-| **Recommended Version** | 2.4.0 |
-| **Minimum version** | `1.46.0` <!-- TODO: bump when we rely on a newer API --> |
-| **Why this floor?** | Introduced <https://deno.land/api?s=Deno.watchFs> debounce fix and Worker `name` option we use for logging. |
-| **Tested on** | macOS 14, Windows 11, Ubuntu 22.04 |
+| Item                    | Value                                                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Recommended Version** | 2.4.0                                                                                                       |
+| **Minimum version**     | `1.46.0` <!-- TODO: bump when we rely on a newer API -->                                                    |
+| **Why this floor?**     | Introduced <https://deno.land/api?s=Deno.watchFs> debounce fix and Worker `name` option we use for logging. |
+| **Tested on**           | macOS 14, Windows 11, Ubuntu 22.04                                                                          |
 
 > **Tip** – Developers can `deno task setup` (see `deno.json`) to auto-verify
 > their local version.
@@ -23,10 +23,10 @@ them.
 
 ## 2. Third-party modules (runtime)
 
-| Import | SemVer / tag | Purpose |
-| ------ | ------------ | ------- |
-| `jsr:@std/toml` | `1.0.0` | Parse page front-matter. |
-| `jsr:@b-fuze/deno-dom` | `0.1.36` | Server-side DOM for HTML manipulation. |
+| Import                 | SemVer / tag | Purpose                                |
+| ---------------------- | ------------ | -------------------------------------- |
+| `jsr:@std/toml`        | `1.0.0`      | Parse page front-matter.               |
+| `jsr:@b-fuze/deno-dom` | `0.1.36`     | Server-side DOM for HTML manipulation. |
 
 Both are **ESM** modules loaded from the official JSR registry, so they’re
 fetched, cached, and locked by Deno automatically.
@@ -37,11 +37,11 @@ fetched, cached, and locked by Deno automatically.
 
 ## 3. Third-party modules (dev / CLI tasks)
 
-| Tool | Version | Task |
-| ---- | ------- | ---- |
-| `deno fmt` | same as runtime | Code formatting |
-| `deno lint` | ″ | Static analysis |
-| `deno_task_shell` | latest | Cross-platform task runner (optional) |
+| Tool              | Version         | Task                                  |
+| ----------------- | --------------- | ------------------------------------- |
+| `deno fmt`        | same as runtime | Code formatting                       |
+| `deno lint`       | ″               | Static analysis                       |
+| `deno_task_shell` | latest          | Cross-platform task runner (optional) |
 
 Unit tests are written with Deno’s built-in `std/testing` library—no external
 test runner needed.
@@ -53,7 +53,7 @@ test runner needed.
 Templates are loaded via dynamic `import()`; Deno caches them by full specifier
 path, so edits pick up **after a watcher invalidates that cache key**.
 
-> No *eval* or unsafe code execution is used—imports are strictly file-system
+> No _eval_ or unsafe code execution is used—imports are strictly file-system
 > paths under `/templates/`.
 
 ---
@@ -62,11 +62,11 @@ path, so edits pick up **after a watcher invalidates that cache key**.
 
 These libraries are **not yet included** but may appear as features land:
 
-| Feature | Candidate module | Status |
-| ------- | ---------------- | ------ |
-| Image optimisation | `jsr:@imagor/deno-lib` | **TODO** – evaluate quality & license |
-| Markdown → HTML | `jsr:@std/markdown` | **Planned** |
-| Minify HTML/CSS/JS | `jsr:@minify/html` (hypothetical) | **Research** |
+| Feature            | Candidate module                  | Status                                |
+| ------------------ | --------------------------------- | ------------------------------------- |
+| Image optimisation | `jsr:@imagor/deno-lib`            | **TODO** – evaluate quality & license |
+| Markdown → HTML    | built-in parser                   | ✅                                    |
+| Minify HTML/CSS/JS | `jsr:@minify/html` (hypothetical) | **Research**                          |
 
 Any new dependency will be proposed via PR with **bundle size impact** notes.
 
@@ -74,15 +74,15 @@ Any new dependency will be proposed via PR with **bundle size impact** notes.
 
 ## 6. Security & update cadence
 
-* We pin exact versions in `import_map.json`.
-* A weekly `deno check-updates` CI job opens PRs for patch / minor bumps.
-* Any **security advisory** triggers an immediate patch release.
+- We pin exact versions in `import_map.json`.
+- A weekly `deno check-updates` CI job opens PRs for patch / minor bumps.
+- Any **security advisory** triggers an immediate patch release.
 
 <!-- TODO: write Github workflow file once repo is public. -->
 
 ---
 
 ### Next steps
-* Back to **README** for an end-to-end quick-start.
-* Or jump ahead to **CHANGELOG.md** to see version history.
 
+- Back to **README** for an end-to-end quick-start.
+- Or jump ahead to **CHANGELOG.md** to see version history.

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -5,17 +5,27 @@ import { LinksManager } from "./links.js";
 import { applyTemplates } from "./apply-templates.js";
 import { inlineSvg } from "./inline-svg.js";
 import { getEmoji } from "./emoji.js";
+import { markdownToHTML } from "./markdown.js";
 
 /**
- * Render a single HTML source file to its output destination.
+ * Render a single HTML or Markdown source file to its output destination.
  *
- * @param {string} path Absolute path to the source HTML file.
+ * @param {string} path Absolute path to the source HTML or Markdown file.
  * @param {URL} [root] Base URL used to resolve template locations.
  * @returns {Promise<{pagePath:string,templatesUsed:string[],svgsUsed:string[],scriptsUsed:string[]}|undefined>}
  */
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {
     const page = await parsePage(path);
+
+    if (path.toLowerCase().endsWith(".md")) {
+      try {
+        page.html = markdownToHTML(page.html);
+      } catch (err) {
+        if (err instanceof Error) err.message = `${path}: ${err.message}`;
+        throw err;
+      }
+    }
 
     const siteDir = await findSiteRoot(path);
     const configPath = join(siteDir, "config.json");
@@ -118,7 +128,7 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
 /**
  * Remove the rendered HTML output associated with a source file.
  *
- * @param {string} path Absolute path to the source HTML file.
+ * @param {string} path Absolute path to the source HTML or Markdown file.
  * @returns {Promise<void>} Resolves when the output file has been removed.
  */
 export async function removePage(path) {
@@ -145,10 +155,10 @@ export async function removePage(path) {
  * @returns {string} Href beginning with a leading slash.
  */
 function toHref(rel, pretty) {
-  const normalized = rel.replace(/\\/g, "/");
+  const normalized = rel.replace(/\\/g, "/").replace(/\.(md|html?)$/i, ".html");
   if (!pretty) return "/" + normalized;
   return "/" +
-    normalized.replace(/index\.html?$/i, "").replace(/\.html?$/i, "/");
+    normalized.replace(/index\.html$/i, "").replace(/\.html$/i, "/");
 }
 
 /**
@@ -165,9 +175,9 @@ function toOutRel(rel, pretty) {
     // Ensure the file keeps a `.html` extension without nesting it under an
     // additional directory. Previously this would transform `foo.html` into
     // `foo/index.html` which broke references to the generated file.
-    return normalized.replace(/\.html?$/i, ".html");
+    return normalized.replace(/\.(md|html?)$/i, ".html");
   }
-  return normalized.replace(/\.html?$/i, "") + ".html";
+  return normalized.replace(/\.(md|html?)$/i, "") + ".html";
 }
 
 /**

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -187,7 +187,7 @@ export function reduceEvents(events) {
 export function classifyPath(path) {
   const p = path.replace(/\\/g, "/");
   const lower = p.toLowerCase();
-  if (lower.endsWith(".html")) return "PAGE_HTML";
+  if (lower.endsWith(".html") || lower.endsWith(".md")) return "PAGE_HTML";
   if (lower.includes("/templates/") && lower.endsWith(".js")) return "TEMPLATE";
   if (lower.includes("/src-svg/") && lower.endsWith(".svg")) {
     return "SVG_INLINE";

--- a/tests/render-markdown.test.js
+++ b/tests/render-markdown.test.js
@@ -1,0 +1,47 @@
+import { renderPage } from "../lib/render-page.js";
+import { join, toFileUrl } from "@std/path";
+import { DOMParser } from "@b-fuze/deno-dom";
+
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+function assertEquals(a, b) {
+  const da = JSON.stringify(a);
+  const db = JSON.stringify(b);
+  if (da !== db) throw new Error(`Expected ${db}, got ${da}`);
+}
+
+Deno.test("renderPage converts markdown sources", async () => {
+  const root = await Deno.makeTempDir();
+  const rootUrl = toFileUrl(root + "/");
+  const siteDir = join(root, "mysite");
+  const distDir = join(root, "dist");
+  await Deno.mkdir(siteDir, { recursive: true });
+  await Deno.mkdir(distDir, { recursive: true });
+
+  await Deno.writeTextFile(
+    join(siteDir, "config.json"),
+    JSON.stringify({ distantDirectory: distDir }),
+  );
+
+  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "head", "default.js"),
+    "export function render({ frontMatter }) { return `<title>${frontMatter.title}</title>`; }",
+  );
+
+  const pagePath = join(siteDir, "index.md");
+  const md =
+    `title = "Title"\n[templates]\nhead = "default"\n#---#\n# Hello\nThis is *markdown*.`;
+  await Deno.writeTextFile(pagePath, md);
+
+  await renderPage(pagePath, rootUrl);
+
+  const outPath = join(distDir, "index.html");
+  const html = await Deno.readTextFile(outPath);
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+  assert(doc);
+  assert(doc.querySelector("h1")?.textContent === "Hello");
+  assert(doc.querySelector("p em")?.textContent === "markdown");
+});


### PR DESCRIPTION
## Summary
- handle `.md` pages by converting to HTML before normal rendering
- treat Markdown files like HTML in path helpers and the file watcher
- document Markdown support across roadmap and spec docs

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688fa6a2444883318ae7020c3c28a4ca