### PR TITLE
feat: add hashed asset support

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -23,14 +23,14 @@ implementation status.
 | `--verbose` CLI flag                 | 🚧     | Extra timing info                      |
 | Config `baseUrl`                     | 🚧     | Inject canonical URLs                  |
 | Config `prettyUrls`                  | ✅     | Omit `.html` in links                  |
-| Config `hashAssets`                  | 🚧     | Content‑hashed asset filenames         |
+| Config `hashAssets`                  | ✅     | Content‑hashed asset filenames         |
 | Config `cleanOutput`                 | 🚧     | Remove stale files                     |
 | CLI `--outDir` override              | 🚧     | Temporarily change `distantDirectory`  |
 | Links CLI `--rebuild-links`          | 🚧     | Regenerate `links.json`                |
 | Watcher CLI `--debounce`             | 🚧     | Adjust debounce window                 |
 | Watcher CLI `--ignore`               | 🚧     | Exclude paths                          |
 | Watcher CLI `--poll`                 | 🚧     | Polling fallback                       |
-| Hash‑based filenames                 | 🚧     | For cache busting                      |
+| Hash‑based filenames                 | ✅     | For cache busting                      |
 | Clean up deleted assets              | ✅     | Source removals delete outputs         |
 | Image optimisation                   | 🔍     | Investigate plugin                     |
 | Symlink instead of copy              | 🤔     | Evaluate for dev convenience           |

--- a/docs/07-config-schema.md
+++ b/docs/07-config-schema.md
@@ -14,6 +14,7 @@ compiled site and (soon) several optional behaviours.
 | ------------------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `distantDirectory` | string  | **Yes**  | **Absolute** path where the rendered site will be written. Use forward slashes on macOS/Linux; Windows paths may use either `C:\\path` or `C:/path` and are normalised internally. |
 | `prettyUrls`       | boolean | No       | If `true`, generator omits `.html` extensions in links and writes `index.html` files in matching folders.                                                                          |
+| `hashAssets`       | boolean | No       | When enabled, CSS and JS filenames receive a short content hash (e.g. `app.4f3d.css`) for cache busting.                                                                           |
 
 > If the path does **not** exist, Kobra Kreator creates it recursively. If it
 > **does** exist but is **not empty**, existing files are overwritten when
@@ -26,11 +27,10 @@ compiled site and (soon) several optional behaviours.
 These keys are **not yet implemented** but are listed here so integrators can
 begin planning. They will be added through minor/major version bumps.
 
-| Key           | Type    | Default | Purpose                                                                                                                                        |
-| ------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `baseUrl`     | string  | `"/"`   | Public URL prefix injected into templates for canonical links, OG tags, etc. <!-- TODO: confirm need & exact semantics. -->                    |
-| `hashAssets`  | boolean | `false` | When enabled, CSS/JS filenames receive a content hash (e.g. `app.4f3d.css`) for cache busting. <!-- TODO: design hash strategy & manifest. --> |
-| `cleanOutput` | boolean | `false` | Remove files in `distantDirectory` that no longer exist in source. Useful for CI. <!-- TODO: evaluate performance impact. -->                  |
+| Key           | Type    | Default | Purpose                                                                                                                       |
+| ------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`     | string  | `"/"`   | Public URL prefix injected into templates for canonical links, OG tags, etc. <!-- TODO: confirm need & exact semantics. -->   |
+| `cleanOutput` | boolean | `false` | Remove files in `distantDirectory` that no longer exist in source. Useful for CI. <!-- TODO: evaluate performance impact. --> |
 
 Feel free to open a GitHub discussion if you need additional knobs.
 
@@ -45,10 +45,10 @@ Feel free to open a GitHub discussion if you need additional knobs.
 
   // v1 – optional extras
   "prettyUrls": true,
+  "hashAssets": true,
 
   // v2 – planned extras (currently ignored)
   "baseUrl": "https://my-domain.com/",
-  "hashAssets": true,
   "cleanOutput": true
 }
 ```
@@ -78,8 +78,12 @@ so editors like VS Code can auto‑validate.
     "prettyUrls": {
       "type": "boolean",
       "description": "Omit .html extensions in links and emit index.html"
+    },
+    "hashAssets": {
+      "type": "boolean",
+      "description": "Add content hash to CSS and JS filenames"
     }
-    /* TODO: add baseUrl, hashAssets, cleanOutput once supported */
+    /* TODO: add baseUrl, cleanOutput once supported */
   }
 }
 ```

--- a/docs/10-file-copy-rules.md
+++ b/docs/10-file-copy-rules.md
@@ -67,7 +67,7 @@ RAM blow-ups for big videos.
 
 | Feature                                    | Status      | Notes                                                                     |
 | ------------------------------------------ | ----------- | ------------------------------------------------------------------------- |
-| **Hash-based filenames** for cache busting | Planned     | Tied to `hashAssets` in _07-config-schema_.                               |
+| **Hash-based filenames** for cache busting | Done        | Enabled via `hashAssets` in _07-config-schema_.                           |
 | **Clean up deleted assets**                | Done        | Source removals delete corresponding output files.                        |
 | **Image optimisation (lossless)**          | Investigate | Could be opt-in plugin.                                                   |
 | **Symlink instead of copy** on same volume | Evaluate    | Saves disk during dev; risky for deployment. <!-- TODO: decide policy --> |

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -1,5 +1,6 @@
-import { dirname, join, relative } from "@std/path";
+import { basename, dirname, join, relative } from "@std/path";
 import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
+import { hashAssetName } from "./hash-asset.js";
 
 /**
  * Copy an asset from the source tree to its distant output directory.
@@ -23,7 +24,32 @@ export async function copyAsset(path) {
   const configText = await Deno.readTextFile(configPath);
   const config = JSON.parse(configText);
   const distant = String(config.distantDirectory);
-  const outPath = join(distant, rel);
+  let outRel = rel;
+  if (config.hashAssets && (ext === ".css" || ext === ".js")) {
+    const dirRel = dirname(rel);
+    const base = basename(rel, ext);
+    const hashed = await hashAssetName(path);
+    const outDir = join(distant, dirRel);
+    try {
+      for await (const entry of Deno.readDir(outDir)) {
+        if (
+          entry.isFile &&
+          entry.name.startsWith(`${base}.`) &&
+          entry.name.endsWith(ext) &&
+          entry.name !== hashed
+        ) {
+          await Deno.remove(join(outDir, entry.name));
+        }
+      }
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+    outRel = (dirRel === "." ? hashed : join(dirRel, hashed)).replace(
+      /\\/g,
+      "/",
+    );
+  }
+  const outPath = join(distant, outRel);
   await Deno.mkdir(dirname(outPath), { recursive: true });
   await Deno.copyFile(path, outPath);
 }
@@ -46,6 +72,25 @@ export async function removeAsset(path) {
   const configText = await Deno.readTextFile(configPath);
   const config = JSON.parse(configText);
   const distant = String(config.distantDirectory);
+  if (config.hashAssets && (ext === ".css" || ext === ".js")) {
+    const dirRel = dirname(rel);
+    const base = basename(rel, ext);
+    const outDir = join(distant, dirRel);
+    try {
+      for await (const entry of Deno.readDir(outDir)) {
+        if (
+          entry.isFile &&
+          entry.name.startsWith(`${base}.`) &&
+          entry.name.endsWith(ext)
+        ) {
+          await Deno.remove(join(outDir, entry.name));
+        }
+      }
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+    return;
+  }
   const outPath = join(distant, rel);
   try {
     await Deno.remove(outPath);

--- a/lib/copy-asset.test.js
+++ b/lib/copy-asset.test.js
@@ -1,4 +1,5 @@
 import { copyAsset, removeAsset } from "./copy-asset.js";
+import { hashAssetName } from "./hash-asset.js";
 import { assert, assertEquals } from "@std/assert";
 import { dirname, join } from "@std/path";
 
@@ -45,6 +46,41 @@ Deno.test("removeAsset deletes destination file", async () => {
   await Deno.writeTextFile(srcFile, "console.log('hi')");
   await copyAsset(srcFile);
   const outFile = join(distant, "js", "app.js");
+  await removeAsset(srcFile);
+  const exists = await fileExists(outFile);
+  assertEquals(exists, false);
+});
+
+Deno.test("hashAssets adds content hash to filenames", async () => {
+  const root = await Deno.makeTempDir();
+  const distant = join(root, "dist");
+  await Deno.writeTextFile(
+    join(root, "config.json"),
+    JSON.stringify({ distantDirectory: distant, hashAssets: true }),
+  );
+  const srcFile = join(root, "css", "style.css");
+  await Deno.mkdir(dirname(srcFile), { recursive: true });
+  await Deno.writeTextFile(srcFile, "body{}");
+  await copyAsset(srcFile);
+  const hashed = await hashAssetName(srcFile);
+  const outFile = join(distant, "css", hashed);
+  const stat = await Deno.stat(outFile);
+  assert(stat.isFile);
+});
+
+Deno.test("removeAsset deletes hashed files", async () => {
+  const root = await Deno.makeTempDir();
+  const distant = join(root, "dist");
+  await Deno.writeTextFile(
+    join(root, "config.json"),
+    JSON.stringify({ distantDirectory: distant, hashAssets: true }),
+  );
+  const srcFile = join(root, "js", "app.js");
+  await Deno.mkdir(dirname(srcFile), { recursive: true });
+  await Deno.writeTextFile(srcFile, "console.log('hi')");
+  await copyAsset(srcFile);
+  const hashed = await hashAssetName(srcFile);
+  const outFile = join(distant, "js", hashed);
   await removeAsset(srcFile);
   const exists = await fileExists(outFile);
   assertEquals(exists, false);

--- a/lib/hash-asset.js
+++ b/lib/hash-asset.js
@@ -1,0 +1,22 @@
+import { basename } from "@std/path";
+
+/**
+ * Generate a filename with an 8-character SHA-1 hash of the file's contents.
+ *
+ * @param {string} filePath Absolute path to the asset file.
+ * @returns {Promise<string>} Basename including hash before the extension.
+ */
+export async function hashAssetName(filePath) {
+  const data = await Deno.readFile(filePath);
+  const buf = await crypto.subtle.digest("SHA-1", data);
+  const hash = Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 8);
+  const base = basename(filePath);
+  const idx = base.lastIndexOf(".");
+  if (idx === -1) return `${base}.${hash}`;
+  const name = base.slice(0, idx);
+  const ext = base.slice(idx);
+  return `${name}.${hash}${ext}`;
+}

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,4 +1,5 @@
 import { dirname, join, relative, toFileUrl } from "@std/path";
+import { hashAssetName } from "./hash-asset.js";
 import { DOMParser } from "@b-fuze/deno-dom";
 import { parsePage } from "./parse-page.js";
 import { LinksManager } from "./links.js";
@@ -33,6 +34,36 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const config = JSON.parse(configText);
     const distant = String(config.distantDirectory);
     const pretty = Boolean(config.prettyUrls);
+    const hashAssets = Boolean(config.hashAssets);
+
+    if (hashAssets) {
+      const cssFiles = page.frontMatter.css ?? [];
+      page.frontMatter.css = await Promise.all(
+        cssFiles.map(async (href) => {
+          const abs = join(
+            siteDir,
+            href.startsWith("/") ? href.slice(1) : href,
+          );
+          const hashed = await hashAssetName(abs);
+          const dirRel = dirname(href.startsWith("/") ? href.slice(1) : href);
+          const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+            .replace(/\\/g, "/");
+          return href.startsWith("/") ? "/" + relPath : relPath;
+        }),
+      );
+      const moduleFiles = page.scripts.modules ?? [];
+      page.scripts.modules = await Promise.all(
+        moduleFiles.map(async (src) => {
+          const abs = join(siteDir, src.startsWith("/") ? src.slice(1) : src);
+          const hashed = await hashAssetName(abs);
+          const relSrc = src.startsWith("/") ? src.slice(1) : src;
+          const dirRel = dirname(relSrc);
+          const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+            .replace(/\\/g, "/");
+          return src.startsWith("/") ? "/" + relPath : relPath;
+        }),
+      );
+    }
 
     const linksManager = new LinksManager(join(siteDir, "links.json"));
     await linksManager.load();

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -13,6 +13,10 @@
     "prettyUrls": {
       "type": "boolean",
       "description": "Omit .html extensions and emit index.html files"
+    },
+    "hashAssets": {
+      "type": "boolean",
+      "description": "Add content hash to CSS and JS filenames"
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow enabling hashed CSS/JS filenames via `hashAssets`
- hash asset filenames during copy and rewrite references in pages
- document new `hashAssets` option and update roadmap

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_688faabf8bac83319248a8037adce56d