### PR TITLE
docs: clarify hashAssets behavior

### DIFF
--- a/docs/07-config-schema.md
+++ b/docs/07-config-schema.md
@@ -14,11 +14,13 @@ compiled site and (soon) several optional behaviours.
 | ------------------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `distantDirectory` | string  | **Yes**  | **Absolute** path where the rendered site will be written. Use forward slashes on macOS/Linux; Windows paths may use either `C:\\path` or `C:/path` and are normalised internally. |
 | `prettyUrls`       | boolean | No       | If `true`, generator omits `.html` extensions in links and writes `index.html` files in matching folders.                                                                          |
-| `hashAssets`       | boolean | No       | When enabled, CSS and JS filenames receive a short content hash (e.g. `app.4f3d.css`) for cache busting.                                                                           |
+| `hashAssets`       | boolean | No       | Renames CSS and JS files to `name.<hash>.ext` for cache busting, removing the un‑hashed file and any outdated hashes. Pages that reference these assets must be rebuilt when the asset changes. |
 
 > If the path does **not** exist, Kobra Kreator creates it recursively. If it
 > **does** exist but is **not empty**, existing files are overwritten when
 > pages/assets share the same relative path.
+
+> When `hashAssets` updates an asset's filename, rebuild any pages that link to it so their references point to the new hash.
 
 ---
 
@@ -81,7 +83,7 @@ so editors like VS Code can auto‑validate.
     },
     "hashAssets": {
       "type": "boolean",
-      "description": "Add content hash to CSS and JS filenames"
+      "description": "Rename CSS and JS files to name.<hash>.ext and remove old copies"
     }
     /* TODO: add baseUrl, cleanOutput once supported */
   }

--- a/docs/10-file-copy-rules.md
+++ b/docs/10-file-copy-rules.md
@@ -63,11 +63,17 @@ RAM blow-ups for big videos.
 
 ---
 
-## 5. Future roadmap
+## 5. Hash-based filenames
+
+If `hashAssets` is enabled (see [07-config-schema](07-config-schema.md)), CSS and JS files are copied as `name.<hash>.ext`. The original un-hashed file and any outdated hashed copies in the output directory are removed. Because pages reference these hashed filenames, any page that links to a changed asset must be rebuilt to update the hash.
+
+---
+
+## 6. Future roadmap
 
 | Feature                                    | Status      | Notes                                                                     |
 | ------------------------------------------ | ----------- | ------------------------------------------------------------------------- |
-| **Hash-based filenames** for cache busting | Done        | Enabled via `hashAssets` in _07-config-schema_.                           |
+| **Hash-based filenames** for cache busting | Done        | Enabled via `hashAssets` in _07-config-schema_; see section 5.|
 | **Clean up deleted assets**                | Done        | Source removals delete corresponding output files.                        |
 | **Image optimisation (lossless)**          | Investigate | Could be opt-in plugin.                                                   |
 | **Symlink instead of copy** on same volume | Evaluate    | Saves disk during dev; risky for deployment. <!-- TODO: decide policy --> |


### PR DESCRIPTION
## Summary
- explain hashAssets behavior in config schema, including renaming and cleanup
- document asset hashing and rebuild implications in file copy rules

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688fb47351608331be7c49ae196de323