### PR TITLE
Clean up un-hashed assets when hashing

### DIFF
--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -30,6 +30,13 @@ export async function copyAsset(path) {
     const base = basename(rel, ext);
     const hashed = await hashAssetName(path);
     const outDir = join(distant, dirRel);
+    // Remove any existing un-hashed asset to avoid stale files.
+    const unhashed = join(outDir, `${base}${ext}`);
+    try {
+      await Deno.remove(unhashed);
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
     try {
       for await (const entry of Deno.readDir(outDir)) {
         if (
@@ -76,6 +83,13 @@ export async function removeAsset(path) {
     const dirRel = dirname(rel);
     const base = basename(rel, ext);
     const outDir = join(distant, dirRel);
+    // Remove the un-hashed file before clearing hashed variants.
+    const unhashed = join(outDir, `${base}${ext}`);
+    try {
+      await Deno.remove(unhashed);
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
     try {
       for await (const entry of Deno.readDir(outDir)) {
         if (

--- a/lib/copy-asset.test.js
+++ b/lib/copy-asset.test.js
@@ -86,6 +86,37 @@ Deno.test("removeAsset deletes hashed files", async () => {
   assertEquals(exists, false);
 });
 
+Deno.test(
+  "hashAssets removes un-hashed files when copying and removing",
+  async () => {
+    const root = await Deno.makeTempDir();
+    const distant = join(root, "dist");
+    await Deno.writeTextFile(
+      join(root, "config.json"),
+      JSON.stringify({ distantDirectory: distant, hashAssets: true }),
+    );
+    const srcFile = join(root, "css", "style.css");
+    await Deno.mkdir(dirname(srcFile), { recursive: true });
+    await Deno.writeTextFile(srcFile, "body{}");
+    const outFile = join(distant, "css", "style.css");
+    await Deno.mkdir(dirname(outFile), { recursive: true });
+    await Deno.writeTextFile(outFile, "stale");
+    await copyAsset(srcFile);
+    const hashed = await hashAssetName(srcFile);
+    const hashedOut = join(distant, "css", hashed);
+    let exists = await fileExists(outFile);
+    assertEquals(exists, false);
+    exists = await fileExists(hashedOut);
+    assertEquals(exists, true);
+    await Deno.writeTextFile(outFile, "stale");
+    await removeAsset(srcFile);
+    exists = await fileExists(outFile);
+    assertEquals(exists, false);
+    exists = await fileExists(hashedOut);
+    assertEquals(exists, false);
+  },
+);
+
 async function fileExists(path) {
   try {
     await Deno.stat(path);


### PR DESCRIPTION
## Summary
- remove existing un-hashed asset before writing hashed version
- ensure removeAsset deletes both hashed and un-hashed variants
- test hashed workflow cleans up un-hashed files

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688fbac25c948331ad4e2fc07ac3ea65