### PR TITLE
feat: track css and module dependencies

### DIFF
--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -1,8 +1,18 @@
 import { getEmoji } from "./emoji.js";
 
 /**
- * Map of page paths to their template, SVG, and inline script dependencies.
- * @type {Map<string, {templates: Set<string>, svgs: Set<string>, scripts: Set<string>}>}
+ * Map of page paths to their template, SVG, inline script, CSS, and module
+ * script dependencies.
+ * @type {Map<
+ *   string,
+ *   {
+ *     templates: Set<string>,
+ *     svgs: Set<string>,
+ *     scripts: Set<string>,
+ *     css: Set<string>,
+ *     modules: Set<string>,
+ *   }
+ * >}
  */
 export const pageDeps = new Map();
 
@@ -13,6 +23,8 @@ export const pageDeps = new Map();
  * @param {string[]} [templates] Template files referenced by the page.
  * @param {string[]} [svgs] SVG files referenced by the page.
  * @param {string[]} [scripts] Inline script files referenced by the page.
+ * @param {string[]} [css] CSS files referenced by the page.
+ * @param {string[]} [modules] External module scripts referenced by the page.
  * @returns {void}
  */
 export function recordPageDeps(
@@ -20,11 +32,15 @@ export function recordPageDeps(
   templates = [],
   svgs = [],
   scripts = [],
+  css = [],
+  modules = [],
 ) {
   pageDeps.set(pagePath, {
     templates: new Set(templates),
     svgs: new Set(svgs),
     scripts: new Set(scripts),
+    css: new Set(css),
+    modules: new Set(modules),
   });
 }
 
@@ -80,6 +96,46 @@ export function pagesUsingScript(scriptPath) {
   }
   for (const [page, { scripts }] of pageDeps) {
     if (scripts.has(realPath)) out.push(page);
+  }
+  return out;
+}
+
+/**
+ * Get a list of pages that reference a given CSS file.
+ *
+ * @param {string} cssPath Path to the CSS file.
+ * @returns {string[]} Array of page paths referencing the CSS file.
+ */
+export function pagesUsingCss(cssPath) {
+  const out = [];
+  let realPath;
+  try {
+    realPath = Deno.realPathSync(cssPath);
+  } catch {
+    realPath = cssPath;
+  }
+  for (const [page, { css }] of pageDeps) {
+    if (css.has(realPath)) out.push(page);
+  }
+  return out;
+}
+
+/**
+ * Get a list of pages that reference a given external module script.
+ *
+ * @param {string} modulePath Path to the module script file.
+ * @returns {string[]} Array of page paths referencing the module script.
+ */
+export function pagesUsingModule(modulePath) {
+  const out = [];
+  let realPath;
+  try {
+    realPath = Deno.realPathSync(modulePath);
+  } catch {
+    realPath = modulePath;
+  }
+  for (const [page, { modules }] of pageDeps) {
+    if (modules.has(realPath)) out.push(page);
   }
   return out;
 }

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -13,7 +13,16 @@ import { markdownToHTML } from "./markdown.js";
  *
  * @param {string} path Absolute path to the source HTML or Markdown file.
  * @param {URL} [root] Base URL used to resolve template locations.
- * @returns {Promise<{pagePath:string,templatesUsed:string[],svgsUsed:string[],scriptsUsed:string[]}|undefined>}
+ * @returns {Promise<
+ *   {
+ *     pagePath: string,
+ *     templatesUsed: string[],
+ *     svgsUsed: string[],
+ *     scriptsUsed: string[],
+ *     cssUsed: string[],
+ *     modulesUsed: string[],
+ *   } | undefined
+ * >}
  */
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {
@@ -36,34 +45,48 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const pretty = Boolean(config.prettyUrls);
     const hashAssets = Boolean(config.hashAssets);
 
-    if (hashAssets) {
-      const cssFiles = page.frontMatter.css ?? [];
-      page.frontMatter.css = await Promise.all(
-        cssFiles.map(async (href) => {
-          const abs = join(
-            siteDir,
-            href.startsWith("/") ? href.slice(1) : href,
-          );
-          const hashed = await hashAssetName(abs);
-          const dirRel = dirname(href.startsWith("/") ? href.slice(1) : href);
-          const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-            .replace(/\\/g, "/");
-          return href.startsWith("/") ? "/" + relPath : relPath;
-        }),
-      );
-      const moduleFiles = page.scripts.modules ?? [];
-      page.scripts.modules = await Promise.all(
-        moduleFiles.map(async (src) => {
-          const abs = join(siteDir, src.startsWith("/") ? src.slice(1) : src);
-          const hashed = await hashAssetName(abs);
-          const relSrc = src.startsWith("/") ? src.slice(1) : src;
-          const dirRel = dirname(relSrc);
-          const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-            .replace(/\\/g, "/");
-          return src.startsWith("/") ? "/" + relPath : relPath;
-        }),
-      );
-    }
+    const cssUsed = [];
+    const cssFiles = page.frontMatter.css ?? [];
+    page.frontMatter.css = await Promise.all(
+      cssFiles.map(async (href) => {
+        const relHref = href.startsWith("/") ? href.slice(1) : href;
+        const abs = join(siteDir, relHref);
+        let real;
+        try {
+          real = await Deno.realPath(abs);
+        } catch {
+          real = abs;
+        }
+        cssUsed.push(real);
+        if (!hashAssets) return href;
+        const hashed = await hashAssetName(abs);
+        const dirRel = dirname(relHref);
+        const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+          .replace(/\\/g, "/");
+        return href.startsWith("/") ? "/" + relPath : relPath;
+      }),
+    );
+    const modulesUsed = [];
+    const moduleFiles = page.scripts.modules ?? [];
+    page.scripts.modules = await Promise.all(
+      moduleFiles.map(async (src) => {
+        const relSrc = src.startsWith("/") ? src.slice(1) : src;
+        const abs = join(siteDir, relSrc);
+        let real;
+        try {
+          real = await Deno.realPath(abs);
+        } catch {
+          real = abs;
+        }
+        modulesUsed.push(real);
+        if (!hashAssets) return src;
+        const hashed = await hashAssetName(abs);
+        const dirRel = dirname(relSrc);
+        const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+          .replace(/\\/g, "/");
+        return src.startsWith("/") ? "/" + relPath : relPath;
+      }),
+    );
 
     const linksManager = new LinksManager(join(siteDir, "links.json"));
     await linksManager.load();
@@ -145,7 +168,14 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       );
     }
 
-    return { pagePath: path, templatesUsed, svgsUsed, scriptsUsed };
+    return {
+      pagePath: path,
+      templatesUsed,
+      svgsUsed,
+      scriptsUsed,
+      cssUsed,
+      modulesUsed,
+    };
   } catch (err) {
     if (err instanceof Error) {
       if (!err.message.includes(path)) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -3,6 +3,8 @@ import {
   pagesUsingScript,
   pagesUsingSvg,
   pagesUsingTemplate,
+  pagesUsingCss,
+  pagesUsingModule,
   recordPageDeps,
 } from "./page-deps.js";
 import {
@@ -40,6 +42,8 @@ function createPool(size) {
           e.data.deps.templatesUsed,
           e.data.deps.svgsUsed,
           e.data.deps.scriptsUsed,
+          e.data.deps.cssUsed,
+          e.data.deps.modulesUsed,
         );
       }
       idle.push(w);
@@ -131,6 +135,38 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
           }
         } else if (kind === "ASSET") {
           tasks.set(`asset:${path}`, { type: "asset", path });
+          const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+          if (ext === ".css") {
+            console.log(`${getEmoji("update")} CSS UPDATED -- ${path}`);
+            const pages = pagesUsingCss(path);
+            if (pages.length === 0) {
+              console.log(
+                `  ${getEmoji("warning")} no pages reference this stylesheet`,
+              );
+            } else {
+              for (const page of pages) {
+                tasks.set(`render:${page}`, { type: "render", path: page });
+              }
+              console.log(
+                `  ${getEmoji("update")} ${pages.length} page(s) updated`,
+              );
+            }
+          } else if (ext === ".js" && !path.endsWith(".inline.js")) {
+            console.log(`${getEmoji("update")} MODULE UPDATED -- ${path}`);
+            const pages = pagesUsingModule(path);
+            if (pages.length === 0) {
+              console.log(
+                `  ${getEmoji("warning")} no pages reference this module`,
+              );
+            } else {
+              for (const page of pages) {
+                tasks.set(`render:${page}`, { type: "render", path: page });
+              }
+              console.log(
+                `  ${getEmoji("update")} ${pages.length} page(s) updated`,
+              );
+            }
+          }
         }
       } else if (evtKind === "remove") {
         if (kind === "PAGE_HTML") {

--- a/lib/watch.test.js
+++ b/lib/watch.test.js
@@ -1,5 +1,13 @@
 import { classifyPath, reduceEvents } from "./watch.js";
-import { assertEquals } from "@std/assert";
+import {
+  pagesUsingCss,
+  pagesUsingModule,
+  recordPageDeps,
+  clearPageDeps,
+} from "./page-deps.js";
+import { renderPage } from "./render-page.js";
+import { join, toFileUrl } from "@std/path";
+import { assertEquals, assertNotEquals } from "@std/assert";
 
 denoTest();
 
@@ -30,5 +38,99 @@ function denoTest() {
     assertEquals(classifyPath("/src/site/foo.inline.js"), "JS_INLINE");
     assertEquals(classifyPath("/src/site/js/app.js"), "ASSET");
     assertEquals(classifyPath("/src/site/media/logo.png"), "ASSET");
+  });
+
+  Deno.test("modifying css triggers re-render with updated hash", async () => {
+    clearPageDeps();
+    const root = await Deno.makeTempDir();
+    const dist = join(root, "dist");
+    await Deno.writeTextFile(
+      join(root, "config.json"),
+      JSON.stringify({ distantDirectory: dist, hashAssets: true }),
+    );
+    await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+    await Deno.copyFile(
+      join(Deno.cwd(), "tests", "templates", "head", "default.js"),
+      join(root, "templates", "head", "base.js"),
+    );
+    const cssPath = join(root, "style.css");
+    await Deno.writeTextFile(cssPath, "body{color:red;}");
+    const pagePath = join(root, "index.html");
+    await Deno.writeTextFile(
+      pagePath,
+      [
+        'title = "Home"',
+        'templates.head = "base"',
+        'css = ["style.css"]',
+        '#---#',
+        '<h1>hi</h1>',
+      ].join("\n"),
+    );
+    const deps1 = await renderPage(pagePath, toFileUrl(root + "/"));
+    if (!deps1) throw new Error("render failed");
+    recordPageDeps(
+      deps1.pagePath,
+      deps1.templatesUsed,
+      deps1.svgsUsed,
+      deps1.scriptsUsed,
+      deps1.cssUsed,
+      deps1.modulesUsed,
+    );
+    const out1 = await Deno.readTextFile(join(dist, "index.html"));
+    const cssHref1 = out1.match(/href="([^"]+)"/)[1];
+    await Deno.writeTextFile(cssPath, "body{color:blue;}");
+    const pages = pagesUsingCss(cssPath);
+    assertEquals(pages, [pagePath]);
+    await renderPage(pagePath, toFileUrl(root + "/"));
+    const out2 = await Deno.readTextFile(join(dist, "index.html"));
+    const cssHref2 = out2.match(/href="([^"]+)"/)[1];
+    assertNotEquals(cssHref1, cssHref2);
+  });
+
+  Deno.test("modifying module triggers re-render with updated hash", async () => {
+    clearPageDeps();
+    const root = await Deno.makeTempDir();
+    const dist = join(root, "dist");
+    await Deno.writeTextFile(
+      join(root, "config.json"),
+      JSON.stringify({ distantDirectory: dist, hashAssets: true }),
+    );
+    await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+    await Deno.copyFile(
+      join(Deno.cwd(), "tests", "templates", "head", "default.js"),
+      join(root, "templates", "head", "base.js"),
+    );
+    const modulePath = join(root, "mod.js");
+    await Deno.writeTextFile(modulePath, "console.log('a');");
+    const pagePath = join(root, "index.html");
+    await Deno.writeTextFile(
+      pagePath,
+      [
+        'title = "Home"',
+        'templates.head = "base"',
+        'scripts.modules = ["mod.js"]',
+        '#---#',
+        '<h1>hi</h1>',
+      ].join("\n"),
+    );
+    const deps1 = await renderPage(pagePath, toFileUrl(root + "/"));
+    if (!deps1) throw new Error("render failed");
+    recordPageDeps(
+      deps1.pagePath,
+      deps1.templatesUsed,
+      deps1.svgsUsed,
+      deps1.scriptsUsed,
+      deps1.cssUsed,
+      deps1.modulesUsed,
+    );
+    const out1 = await Deno.readTextFile(join(dist, "index.html"));
+    const src1 = out1.match(/src="([^"]+)"/)[1];
+    await Deno.writeTextFile(modulePath, "console.log('b');");
+    const pages = pagesUsingModule(modulePath);
+    assertEquals(pages, [pagePath]);
+    await renderPage(pagePath, toFileUrl(root + "/"));
+    const out2 = await Deno.readTextFile(join(dist, "index.html"));
+    const src2 = out2.match(/src="([^"]+)"/)[1];
+    assertNotEquals(src1, src2);
   });
 }

--- a/lib/worker-task.js
+++ b/lib/worker-task.js
@@ -21,6 +21,8 @@ self.onmessage = async (e) => {
           deps.templatesUsed,
           deps.svgsUsed,
           deps.scriptsUsed,
+          deps.cssUsed,
+          deps.modulesUsed,
         );
       }
       self.postMessage({ id, deps });


### PR DESCRIPTION
## Summary
- extend page dependency tracking to include css and external modules
- re-render pages when dependent css or modules change
- add regression tests for css and module hashing on rebuild

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_688fbee11f488331a5a3139815072e7c