### PR TITLE
Fix template override watching and cache busting

### DIFF
--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -39,7 +39,10 @@ export async function applyTemplates(
     let moduleUrl = new URL(`templates/${slot}/${name}.js`, root);
     let module;
     try {
-      module = await import(moduleUrl.href);
+      // Bust the module cache so newly created or modified templates are
+      // loaded fresh on every render. Without this, Deno would reuse the
+      // previously cached result and ignore user overrides.
+      module = await import(`${moduleUrl.href}?t=${Date.now()}`);
       used.push(fromFileUrl(moduleUrl));
     } catch (err) {
       if (

--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -52,10 +52,34 @@ export function recordPageDeps(
  */
 export function pagesUsingTemplate(templatePath) {
   const out = [];
+  const target = normalizeTemplatePath(templatePath);
   for (const [page, deps] of pageDeps) {
-    if (deps.templates.has(templatePath)) out.push(page);
+    for (const t of deps.templates) {
+      if (normalizeTemplatePath(t) === target) {
+        out.push(page);
+        break;
+      }
+    }
   }
   return out;
+}
+
+/**
+ * Reduce a template path to a canonical `slot/name.js` form.
+ *
+ * This allows project templates and their core fallbacks to be treated as the
+ * same dependency when looking up pages that need to be re-rendered.
+ *
+ * @param {string} path Absolute template file path.
+ * @returns {string} Normalized relative path.
+ */
+function normalizeTemplatePath(path) {
+  const p = path.replace(/\\/g, "/");
+  const tplIdx = p.indexOf("/templates/");
+  if (tplIdx !== -1) return p.slice(tplIdx + 11);
+  const coreIdx = p.indexOf("/core/templates/");
+  if (coreIdx !== -1) return p.slice(coreIdx + 16);
+  return p;
 }
 
 /**

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -173,6 +173,11 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
           tasks.set(`remove:${path}`, { type: "remove-page", path });
         } else if (kind === "ASSET") {
           tasks.set(`remove:${path}`, { type: "remove-asset", path });
+        } else if (kind === "TEMPLATE") {
+          console.log(`${getEmoji("delete")} TEMPLATE REMOVED -- ${path}`);
+          for (const page of pagesUsingTemplate(path)) {
+            tasks.set(`render:${page}`, { type: "render", path: page });
+          }
         }
       }
     }

--- a/lib/watch.test.js
+++ b/lib/watch.test.js
@@ -4,6 +4,7 @@ import {
   pagesUsingModule,
   recordPageDeps,
   clearPageDeps,
+  pagesUsingTemplate,
 } from "./page-deps.js";
 import { renderPage } from "./render-page.js";
 import { join, toFileUrl } from "@std/path";
@@ -38,6 +39,16 @@ function denoTest() {
     assertEquals(classifyPath("/src/site/foo.inline.js"), "JS_INLINE");
     assertEquals(classifyPath("/src/site/js/app.js"), "ASSET");
     assertEquals(classifyPath("/src/site/media/logo.png"), "ASSET");
+  });
+
+  Deno.test("pagesUsingTemplate resolves core and project overrides", () => {
+    clearPageDeps();
+    const page = "/tmp/page.html";
+    recordPageDeps(page, ["/core/templates/head/default.js"]);
+    assertEquals(pagesUsingTemplate("/templates/head/default.js"), [page]);
+    clearPageDeps();
+    recordPageDeps(page, ["/templates/head/default.js"]);
+    assertEquals(pagesUsingTemplate("/core/templates/head/default.js"), [page]);
   });
 
   Deno.test("modifying css triggers re-render with updated hash", async () => {

--- a/tests/watch-templates.test.js
+++ b/tests/watch-templates.test.js
@@ -1,0 +1,112 @@
+import { renderPage } from "../lib/render-page.js";
+import {
+  clearPageDeps,
+  pagesUsingTemplate,
+  recordPageDeps,
+} from "../lib/page-deps.js";
+import { classifyPath, reduceEvents } from "../lib/watch.js";
+import { join, toFileUrl } from "@std/path";
+
+/**
+ * Simple assertion helper.
+ * @param {unknown} cond Condition expected to be truthy.
+ * @param {string} [msg] Optional assertion message.
+ */
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+
+Deno.test(
+  "adding and removing template overrides re-renders dependent pages",
+  async () => {
+    clearPageDeps();
+    const rootDir = await Deno.makeTempDir();
+    const rootUrl = toFileUrl(rootDir + "/");
+    const siteDir = await Deno.makeTempDir();
+    const distDir = await Deno.makeTempDir();
+
+    await Deno.writeTextFile(
+      join(siteDir, "config.json"),
+      JSON.stringify({ distantDirectory: distDir }),
+    );
+
+    const pagePath = join(siteDir, "index.html");
+    await Deno.writeTextFile(
+      pagePath,
+      `title = "Core"\n[templates]\nhead = "default"\n#---#\n<body></body>`,
+    );
+
+    const deps = await renderPage(pagePath, rootUrl);
+    if (deps) {
+      recordPageDeps(
+        deps.pagePath,
+        deps.templatesUsed,
+        deps.svgsUsed,
+        deps.scriptsUsed,
+      );
+    }
+
+    const outPath = join(distDir, "index.html");
+    let html = await Deno.readTextFile(outPath);
+    assert(html.includes("<title>Core</title>"));
+
+    const tplPath = join(rootDir, "templates", "head", "default.js");
+    await Deno.mkdir(join(rootDir, "templates", "head"), { recursive: true });
+    await Deno.writeTextFile(
+      tplPath,
+      "export function render() { return `<title>Override</title>`; }",
+    );
+
+    let events = [{ kind: "create", paths: [tplPath] }];
+    let paths = reduceEvents(events);
+    for (const [path, evtKind] of paths) {
+      const type = classifyPath(path);
+      if ((evtKind === "create" || evtKind === "modify") && type === "TEMPLATE") {
+        for (const page of pagesUsingTemplate(path)) {
+          const d = await renderPage(page, rootUrl);
+          if (d) {
+            recordPageDeps(
+              d.pagePath,
+              d.templatesUsed,
+              d.svgsUsed,
+              d.scriptsUsed,
+              d.cssUsed,
+              d.modulesUsed,
+            );
+          }
+        }
+      }
+    }
+
+    html = await Deno.readTextFile(outPath);
+    assert(html.includes("<title>Override</title>"));
+
+    await Deno.remove(tplPath);
+
+    events = [{ kind: "remove", paths: [tplPath] }];
+    paths = reduceEvents(events);
+    for (const [path, evtKind] of paths) {
+      const type = classifyPath(path);
+      if (evtKind === "remove" && type === "TEMPLATE") {
+        for (const page of pagesUsingTemplate(path)) {
+          const d = await renderPage(page, rootUrl);
+          if (d) {
+            recordPageDeps(
+              d.pagePath,
+              d.templatesUsed,
+              d.svgsUsed,
+              d.scriptsUsed,
+              d.cssUsed,
+              d.modulesUsed,
+            );
+          }
+        }
+      }
+    }
+
+    html = await Deno.readTextFile(outPath);
+    assert(html.includes("<title>Core</title>"));
+
+    await Deno.remove(rootDir, { recursive: true });
+  },
+);


### PR DESCRIPTION
## Summary
- normalize template dependency tracking so core and project paths map to same pages
- bust template module cache to allow loading new/updated templates
- watch for template removals and re-render affected pages
- add unit and integration tests for template override behaviour

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68907e56d1348331913613ab9fd44b55