### PR TITLE
feat: error when core template missing

### DIFF
--- a/docs/02-directory-layout.md
+++ b/docs/02-directory-layout.md
@@ -52,7 +52,8 @@ project-root/
 1. **Folder == domain.** The folder name must match the domain you will deploy
    under (e.g. `my‑domain.com`). Spaces and uppercase discouraged.
 2. **Templates are global.** All sites pull from the same `/templates` pool, but
-   the folder may be omitted—defaults from `/core/templates` are used instead.
+   the folder may be omitted—matching files from `/core/templates` are used
+   instead.
 3. **Sub‑folders allowed.** Inside any site, you can nest pages arbitrarily
    (e.g. `docs/getting-started.html`) – the relative path is preserved in the
    build output.

--- a/docs/05-templates-api.md
+++ b/docs/05-templates-api.md
@@ -3,8 +3,9 @@
 Templates are **plain ECMAScript modules** that live under the shared
 `/templates/` directory. They generate reusable page fragments—`<head>`,
 `<nav>`, and `<footer>`—based on each page’s front‑matter and the site’s central
-`links.json`. When these project-level templates are absent, Kobra Kreator falls
-back to bundled defaults under `/core/templates/`.
+`links.json`. When these project-level templates are absent, Kobra Kreator
+checks for a template with the **same name** under `/core/templates/`. If no
+matching core template exists, the build fails with an error.
 
 > **TL;DR**: export a `render()` function that returns an HTML string.
 
@@ -27,7 +28,7 @@ _The generator maps the `frontMatter.templates.X` key to
 `/templates/X/<NAME>.js`, where `X ∈ { head, nav, footer }`._
 
 If the `/templates/` directory is missing, Kobra Kreator automatically uses the
-fallback files from `/core/templates/` for each slot.
+files from `/core/templates/` with the same names for each slot.
 
 ---
 
@@ -131,7 +132,8 @@ parameter or named import.
 
 - If a template **throws**, the build logs the error and halts—better fail fast
   than produce broken markup.
-- Missing template file → falls back to `/core/templates/<slot>/default.js`.
+- Missing template file → loads `/core/templates/<slot>/<name>.js`.
+- Missing in both locations → build fails with an error.
 
 ---
 

--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -49,13 +49,28 @@ export async function applyTemplates(
         err instanceof Deno.errors.NotFound ||
         (err && err.message && err.message.includes("Module not found"))
       ) {
-        // Fallback to built-in defaults when project templates are missing.
+        // When a project template is missing, attempt to load the same
+        // template name from the bundled core templates. This allows pages
+        // to continue rendering when a template is renamed or deleted, while
+        // still surfacing an error if no fallback exists.
         moduleUrl = new URL(
-          `../core/templates/${slot}/default.js`,
+          `../core/templates/${slot}/${name}.js`,
           import.meta.url,
         );
-        module = await import(moduleUrl.href);
-        used.push(fromFileUrl(moduleUrl));
+        try {
+          module = await import(moduleUrl.href);
+          used.push(fromFileUrl(moduleUrl));
+        } catch (err2) {
+          if (
+            err2 instanceof Deno.errors.NotFound ||
+            (err2 && err2.message && err2.message.includes("Module not found"))
+          ) {
+            throw new Error(
+              `Template ${slot}/${name}.js not found in project or core directories`,
+            );
+          }
+          throw err2;
+        }
       } else {
         throw err;
       }

--- a/tests/apply-templates.test.js
+++ b/tests/apply-templates.test.js
@@ -107,3 +107,33 @@ Deno.test("applyTemplates falls back to core templates", async () => {
     ].sort(),
   );
 });
+
+Deno.test(
+  "applyTemplates errors when template missing in project and core",
+  async () => {
+    const doc = new StubDocument();
+    doc.body.innerHTML = "<main>hi</main>";
+
+    const frontMatter = {
+      title: "Example",
+      templates: { head: "missing" },
+    };
+    const links = { nav: [], footer: [] };
+
+    const root = new URL("./no-templates/", import.meta.url);
+
+    let threw = false;
+    try {
+      await applyTemplates(doc, frontMatter, links, root);
+    } catch (err) {
+      threw = true;
+      assertEquals(
+        err.message.includes(
+          "Template head/missing.js not found in project or core directories",
+        ),
+        true,
+      );
+    }
+    if (!threw) throw new Error("Expected applyTemplates to throw");
+  },
+);


### PR DESCRIPTION
## Summary
- search for missing templates in core templates with matching name
- document updated core fallback behavior and add regression test

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_6890829475688331b323ac87fb504a41