### PR TITLE
doc: document parsePage result

### DIFF
--- a/lib/parse-page.js
+++ b/lib/parse-page.js
@@ -16,11 +16,23 @@ const NAV_LINK_KEYS = ["topLevel", "subLevel", "label"];
 const FOOTER_LINK_KEYS = ["column", "label"];
 
 /**
+ * @typedef {object} ParseResult
+ * @property {Record<string, unknown>} frontMatter Parsed front-matter data.
+ * @property {Record<string, string>} templates Template names extracted from front-matter.
+ * @property {Record<string, unknown>} scripts Script references extracted from front-matter.
+ * @property {Record<string, unknown>} links Link metadata extracted from front-matter.
+ * @property {string} html Remaining HTML after the front-matter separator.
+ */
+
+/**
  * Parse an HTML file with TOML front-matter.
  *
  * Splits the file at `#---#`, parses the first segment as TOML and validates
  * recognised keys. Unknown keys log a warning. Returns the parsed front-matter
  * alongside the remaining HTML.
+ *
+ * @param {string} path Path to the file being processed.
+ * @returns {Promise<ParseResult>} Parsed front-matter and HTML content.
  */
 export async function parsePage(path) {
   const raw = await Deno.readTextFile(path);


### PR DESCRIPTION
## Summary
- document parsePage return structure via ParseResult typedef
- note parsePage path parameter and return type in JSDoc

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors` *(fails: applyTemplates tests)*

------
https://chatgpt.com/codex/tasks/task_e_689100925d2c833192b33f07fa0288c4