### PR TITLE
docs: consolidate recordPageDeps params

### DIFF
--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -17,14 +17,19 @@ import { getEmoji } from "./emoji.js";
 export const pageDeps = new Map();
 
 /**
+ * @typedef {Record<string, string[]> & {pagePath: string}} PageDeps
+ * @property {string} pagePath Path to the HTML page.
+ * @property {string[]} [templatesUsed] Template files referenced by the page.
+ * @property {string[]} [svgsUsed] SVG files referenced by the page.
+ * @property {string[]} [scriptsUsed] Inline script files referenced by the page.
+ * @property {string[]} [cssUsed] CSS files referenced by the page.
+ * @property {string[]} [modulesUsed] External module scripts referenced by the page.
+ */
+
+/**
  * Record the dependencies used when rendering a page.
  *
- * @param {string} pagePath Path to the HTML page.
- * @param {string[]} [templates] Template files referenced by the page.
- * @param {string[]} [svgs] SVG files referenced by the page.
- * @param {string[]} [scripts] Inline script files referenced by the page.
- * @param {string[]} [css] CSS files referenced by the page.
- * @param {string[]} [modules] External module scripts referenced by the page.
+ * @param {Record<string, string[]> & {pagePath: string}} deps See {@link PageDeps} for property descriptions.
  * @returns {void}
  */
 export function recordPageDeps({
@@ -35,7 +40,9 @@ export function recordPageDeps({
   cssUsed = [],
   modulesUsed = [],
 }) {
-  if (pagePath === undefined) throw new Error(`no argument passed to recordPageDeps`);
+  if (pagePath === undefined) {
+    throw new Error(`no argument passed to recordPageDeps`);
+  }
   pageDeps.set(pagePath, {
     templates: new Set(templatesUsed),
     svgs: new Set(svgsUsed),


### PR DESCRIPTION
## Summary
- consolidate `recordPageDeps` parameters into single `deps` object
- add `PageDeps` typedef documenting dependency properties

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors tests/apply-templates.test.js` *(fails: applyTemplates inserts rendered fragments, applyTemplates handles document with no root element, applyTemplates falls back to core templates)*

------
https://chatgpt.com/codex/tasks/task_e_6891008c81c08331bdc9ed7c97c27956