### PR TITLE
Use workers param in watch and document worker helpers

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -66,11 +66,17 @@ import { WorkerPool } from "./worker-pool.js";
 //   return { push };
 // }
 
-const workerPool = new WorkerPool(
-  new URL("./worker-task.js", import.meta.url).href,
-  2
-);
+/**
+ * @type {WorkerPool}
+ */
+let workerPool;
 
+/**
+ * Queue a page render task with the worker pool.
+ *
+ * @param {string} path - Path to the page to render.
+ * @returns {void}
+ */
 function workerRenderPage(path) {
   workerPool.push({ type: "render", path }, [(e) => recordPageDeps(e.data.deps)]);
 }
@@ -82,6 +88,10 @@ function workerRenderPage(path) {
  * @returns {Promise<void>}
  */
 export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
+  workerPool = new WorkerPool(
+    new URL("./worker-task.js", import.meta.url).href,
+    workers,
+  );
   const src = fromFileUrl(new URL("../src", import.meta.url));
   const templates = fromFileUrl(new URL("../templates", import.meta.url));
 
@@ -108,6 +118,11 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
   const queue = [];
   let timer;
 
+  /**
+   * Process queued filesystem events and dispatch worker tasks.
+   *
+   * @returns {Promise<void>}
+   */
   async function flush() {
     const events = queue.splice(0);
     timer = undefined;
@@ -199,9 +214,15 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
         }
       }
     }
-    await Promise.all([...tasks.values()].map((t) => pool.push(t)));
+    await Promise.all([...tasks.values()].map((t) => workerPool.push(t)));
   }
 
+  /**
+   * Consume events from a file system watcher and queue them for processing.
+   *
+   * @param {Deno.FsWatcher} w - Watcher to read events from.
+   * @returns {Promise<void>}
+   */
   async function handle(w) {
     for await (const evt of w) {
       queue.push(evt);


### PR DESCRIPTION
## Summary
- instantiate `WorkerPool` with configurable worker count
- add JSDoc for `workerRenderPage`, `flush`, and `handle`

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_6891033089588331a48b0df4e515927e