### PR TITLE
docs: refine worker pool jsdoc

### DIFF
--- a/lib/worker-pool.js
+++ b/lib/worker-pool.js
@@ -1,3 +1,8 @@
+/**
+ * Represents a task queued for a worker.
+ * @typedef {{ id?: number, [key: string]: unknown }} WorkerTask
+ */
+
 export class WorkerPool {
   /**
    * @param {string} workerPath - Path to the worker script.
@@ -18,6 +23,12 @@ export class WorkerPool {
     }
   }
 
+  /**
+   * Handle messages emitted by a worker.
+   * @private
+   * @param {Worker} worker - Worker instance that sent the message.
+   * @param {MessageEvent} e - Message event from the worker.
+   */
   _handleMessage(worker, e) {
     const { id } = e.data;
     const job = this.jobs.get(id);
@@ -44,11 +55,21 @@ export class WorkerPool {
     this._runNext();
   }
 
+  /**
+   * Handle errors raised by a worker.
+   * @private
+   * @param {Worker} worker - Worker instance that produced the error.
+   * @param {ErrorEvent} e - Error event emitted by the worker.
+   */
   _handleError(worker, e) {
     console.error(`Worker error: ${e.message}`);
     // Optionally implement retry or worker replacement
   }
 
+  /**
+   * Dispatch the next task in the queue if possible.
+   * @private
+   */
   _runNext() {
     if (this.queue.length === 0 || this.idle.length === 0) return;
     const worker = this.idle.pop();
@@ -61,8 +82,8 @@ export class WorkerPool {
   /**
    * Push a task to the worker pool.
    *
-   * @param {object} taskData - Task data to send to the worker.
-   * @param {Array<function(MessageEvent):void>} [callbacks=[]] - Optional callbacks triggered on message.
+   * @param {WorkerTask} taskData - Task data to send to the worker.
+   * @param {Array<(e: MessageEvent) => void>} [callbacks=[]] - Optional callbacks triggered on message.
    * @returns {Promise<any>}
    */
   push(taskData, callbacks = []) {


### PR DESCRIPTION
## Summary
- document WorkerTask structure and clarify worker pool internals
- tighten worker pool callback types

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_689103307420833189ce31a5a763a158