### PR TITLE
refactor(fs-utils): centralize event and path type aliases

### DIFF
--- a/lib/fs-utils.js
+++ b/lib/fs-utils.js
@@ -1,10 +1,18 @@
 import { MEDIA_EXTENSIONS, SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
 
 /**
+ * @typedef {Deno.FsEvent['kind']} FsEventKind
+ */
+
+/**
+ * @typedef {"PAGE_HTML"|"TEMPLATE"|"SVG_INLINE"|"JS_INLINE"|"ASSET"|null} PathClassification
+ */
+
+/**
  * Collapse multiple filesystem events into the most relevant ones.
  *
  * @param {Deno.FsEvent[]} events Events to reduce.
- * @returns {Map<string, string>} Map of paths to final event kinds.
+ * @returns {Map<string, FsEventKind>} Map of paths to final event kinds.
  */
 export function reduceEvents(events) {
   const result = new Map();
@@ -33,7 +41,7 @@ export function reduceEvents(events) {
  * Classify a filesystem path to determine how it should be handled.
  *
  * @param {string} path Path to classify.
- * @returns {"PAGE_HTML"|"TEMPLATE"|"SVG_INLINE"|"JS_INLINE"|"ASSET"|null} Classification result.
+ * @returns {PathClassification} Classification result.
  */
 export function classifyPath(path) {
   const normalized = path.replace(/\\/g, "/").toLowerCase();


### PR DESCRIPTION
## Summary
- add `FsEventKind` and `PathClassification` typedefs
- use `FsEventKind` in `reduceEvents` return type
- use `PathClassification` in `classifyPath`

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_6891032d92988331be0206061d25983f