### PR TITLE
docs: document renderPage return type

### DIFF
--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -9,20 +9,22 @@ import { getEmoji } from "./emoji.js";
 import { markdownToHTML } from "./markdown.js";
 
 /**
+ * @typedef {object} RenderResult
+ * @property {string} pagePath Path to the source file that was rendered.
+ * @property {string[]} templatesUsed Template files referenced by the page.
+ * @property {string[]} svgsUsed SVG files referenced by the page.
+ * @property {string[]} scriptsUsed Inline script files referenced by the page.
+ * @property {string[]} cssUsed CSS files referenced by the page.
+ * @property {string[]} modulesUsed External module scripts referenced by the page.
+ */
+
+/**
  * Render a single HTML or Markdown source file to its output destination.
  *
  * @param {string} path Absolute path to the source HTML or Markdown file.
  * @param {URL} [root] Base URL used to resolve template locations.
- * @returns {Promise<
- *   {
- *     pagePath: string,
- *     templatesUsed: string[],
- *     svgsUsed: string[],
- *     scriptsUsed: string[],
- *     cssUsed: string[],
- *     modulesUsed: string[],
- *   } | undefined
- * >}
+ * @returns {Promise<RenderResult|undefined>} Dependencies referenced by the
+ * rendered page or `undefined` if an error occurred.
  */
 export async function renderPage(path, root = new URL("..", import.meta.url)) {
   try {


### PR DESCRIPTION
## Summary
- add `RenderResult` typedef summarizing assets referenced when rendering a page
- document `renderPage` to return `Promise<RenderResult|undefined>`

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_6891032ccb0483319c0a7d84e16e71c0