### PR TITLE
docs: document main return type

### DIFF
--- a/scripts/ensure-distant-dirs.js
+++ b/scripts/ensure-distant-dirs.js
@@ -12,6 +12,8 @@ import { getEmoji, logWithEmoji } from "../lib/emoji.js";
  * Walks each immediate subdirectory of `src/`, validates its `config.json`
  * against the configuration schema, normalizes the `distantDirectory` path and
  * ensures the referenced directory exists on disk.
+ *
+ * @returns {Promise<void>}
  */
 async function main() {
   const root = resolve(dirname(fromFileUrl(import.meta.url)), "..");


### PR DESCRIPTION
## Summary
- specify Promise<void> return type in ensure-distant-dirs main JSDoc

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_689104e364a48331857c70c847770c45