### PR TITLE
docs: consolidate template params

### DIFF
--- a/core/templates/footer/default.js
+++ b/core/templates/footer/default.js
@@ -1,12 +1,16 @@
 /**
  * Render the default footer element.
  *
- * @param {{links: {footer?: {href: string, label: string}[]}}} params
- * @param {{config: {copyright?: string}}} params
+ * @param {{
+ *   links: { footer?: { href: string, label: string }[] },
+ *   config: { copyright?: string }
+ * }} params
  * @returns {string}
  */
 export function render({ links, config }) {
-  const copyright = config.copyright ? `<p><small>${copyright}</small></p>`: ""; 
+  const copyright = config.copyright
+    ? `<p><small>${config.copyright}</small></p>`
+    : "";
 
   const items = (links.footer || [])
     .map((l) => `<a href="${l.href}">${l.label}</a>`)

--- a/core/templates/head/default.js
+++ b/core/templates/head/default.js
@@ -1,20 +1,21 @@
 /**
  * Render the default <head> fragment.
  *
- * @param {{frontMatter: {title?: string, css?: string[]}}} params
+ * @param {{ frontMatter: { title?: string, description?: string, css?: string[] } }} params
  * @returns {string}
  */
 export function render({ frontMatter }) {
-
   const {
-  title = "",
-  description = "",
-  css = ["styles.css"]
+    title = "",
+    description = "",
+    css = ["styles.css"],
   } = frontMatter;
 
-  const metaDescription = description ? `<meta name="description" content="${description}">` : "";
-  
-  let cssLinks = '';
+  const metaDescription = description
+    ? `<meta name="description" content="${description}">`
+    : "";
+
+  let cssLinks = "";
   for (const path of css) {
     cssLinks += `\n<link rel="stylesheet" href="/css/${path}">`;
   }

--- a/core/templates/nav/default.js
+++ b/core/templates/nav/default.js
@@ -1,7 +1,7 @@
 /**
  * Render the default navigation element.
  *
- * @param {{links: {nav?: {href: string, label: string}[]}}} params
+ * @param {{ links: { nav?: { href: string, label: string }[] } }} params
  * @returns {string}
  */
 export function render({ links }) {


### PR DESCRIPTION
## Summary
- unify JSDoc param signatures across core head, nav, and footer templates
- note head description and footer copyright options
- fix footer copyright output

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_689104e2ae3883319dd01374e75392db