### PR TITLE
feat: add dropdown nav template

### DIFF
--- a/core/templates/nav/default.js
+++ b/core/templates/nav/default.js
@@ -1,12 +1,49 @@
 /**
- * Render the default navigation element.
+ * Render the default navigation element with optional dropdown menus.
  *
- * @param {{ links: { nav?: { href: string, label: string }[] } }} params
- * @returns {string}
+ * Navigation data originates from `links.json` managed by `LinksManager`.
+ * Each item contains either a `topLevel` flag or a `subLevel` bucket name.
+ * Items sharing the same `subLevel` are grouped into a single dropdown using
+ * the native `<details>` element. Only entries with a `topLevel` flag or a
+ * `subLevel` value are rendered; others are ignored.
+ *
+ * @param {{ links: { nav?: Array<{ href: string, label: string, topLevel?: boolean, subLevel?: string }> } }} params
+ *   Navigation parameters.
+ * @returns {string} Rendered navigation HTML.
  */
 export function render({ links }) {
-  const items = (links.nav || [])
-    .map((l) => `<a href="${l.href}">${l.label}</a>`)
+  const order = [];
+  const buckets = new Map();
+
+  for (const item of links.nav || []) {
+    if (item.subLevel) {
+      // Group items by their `subLevel` bucket while preserving order of
+      // first appearance.
+      let group = buckets.get(item.subLevel);
+      if (!group) {
+        group = { name: item.subLevel, items: [] };
+        buckets.set(item.subLevel, group);
+        order.push(group);
+      }
+      group.items.push(item);
+    } else if (item.topLevel) {
+      // Only explicitly flagged top-level items render as plain links.
+      order.push(item);
+    }
+    // Entries lacking both `topLevel` and `subLevel` are skipped.
+  }
+
+  const items = order
+    .map((entry) => {
+      if (entry.items) {
+        const children = entry.items
+          .map((c) => `<li><a href="${c.href}">${c.label}</a></li>`)
+          .join("");
+        return `<details><summary>${entry.name}</summary><ul>${children}</ul></details>`;
+      }
+      return `<a href="${entry.href}">${entry.label}</a>`;
+    })
     .join("");
+
   return `<nav>${items}</nav>`;
 }

--- a/tests/nav-default.test.js
+++ b/tests/nav-default.test.js
@@ -1,0 +1,32 @@
+import { render } from "../core/templates/nav/default.js";
+
+/**
+ * Minimal equality assertion for tests.
+ * @param {*} actual
+ * @param {*} expected
+ */
+function assertEquals(actual, expected) {
+  const da = JSON.stringify(actual);
+  const db = JSON.stringify(expected);
+  if (da !== db) throw new Error(`Assertion failed: expected ${db}, got ${da}`);
+}
+
+Deno.test("nav template renders dropdown", () => {
+  const links = {
+    nav: [
+      { href: "/", label: "<logo src=\"\"></logo>", topLevel: true },
+      { href: "/ai-generator", label: "Ai Generator", subLevel: "Product" },
+      { href: "/script-reader", label: "Script reader", subLevel: "Product" },
+      { href: "/blog", label: "Blog", topLevel: true },
+    ],
+  };
+  const html = render({ links });
+  const expected = [
+    '<nav><a href="/"><logo src=""></logo></a>',
+    '<details><summary>Product</summary><ul>',
+    '<li><a href="/ai-generator">Ai Generator</a></li>',
+    '<li><a href="/script-reader">Script reader</a></li>',
+    '</ul></details><a href="/blog">Blog</a></nav>',
+  ].join("");
+  assertEquals(html, expected);
+});


### PR DESCRIPTION
## Summary
- align default nav template with LinksManager's links.json structure to group dropdown links via `subLevel` and render top-level anchors
- update dropdown navigation test to reflect new nav data shape

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68910867c1088331aadb1ce205dcedb0