### PR TITLE
watch links re-renders pages

### DIFF
--- a/lib/fs-utils.js
+++ b/lib/fs-utils.js
@@ -1,11 +1,14 @@
-import { MEDIA_EXTENSIONS, SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
+import {
+  MEDIA_EXTENSIONS,
+  SRC_ASSET_EXTENSIONS,
+} from "./extension-whitelist.js";
 
 /**
  * @typedef {Deno.FsEvent['kind']} FsEventKind
  */
 
 /**
- * @typedef {"PAGE_HTML"|"TEMPLATE"|"SVG_INLINE"|"JS_INLINE"|"ASSET"|null} PathClassification
+ * @typedef {"PAGE_HTML"|"TEMPLATE"|"SVG_INLINE"|"JS_INLINE"|"ASSET"|"LINKS_JSON"|null} PathClassification
  */
 
 /**
@@ -46,10 +49,17 @@ export function reduceEvents(events) {
 export function classifyPath(path) {
   const normalized = path.replace(/\\/g, "/").toLowerCase();
 
-  if (normalized.endsWith(".html") || normalized.endsWith(".md")) return "PAGE_HTML";
-  if (normalized.includes("/templates/") && normalized.endsWith(".js")) return "TEMPLATE";
-  if (normalized.includes("/src-svg/") && normalized.endsWith(".svg")) return "SVG_INLINE";
+  if (normalized.endsWith(".html") || normalized.endsWith(".md")) {
+    return "PAGE_HTML";
+  }
+  if (normalized.includes("/templates/") && normalized.endsWith(".js")) {
+    return "TEMPLATE";
+  }
+  if (normalized.includes("/src-svg/") && normalized.endsWith(".svg")) {
+    return "SVG_INLINE";
+  }
   if (normalized.endsWith(".inline.js")) return "JS_INLINE";
+  if (normalized.endsWith("/links.json")) return "LINKS_JSON";
 
   if (normalized.includes("/media/")) {
     const ext = normalized.slice(normalized.lastIndexOf("."));
@@ -63,4 +73,3 @@ export function classifyPath(path) {
 
   return null;
 }
-

--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -1,8 +1,8 @@
 import { getEmoji } from "./emoji.js";
 
 /**
- * Map of page paths to their template, SVG, inline script, CSS, and module
- * script dependencies.
+ * Map of page paths to their template, SVG, inline script, CSS, module script,
+ * and `links` front-matter dependencies.
  * @type {Map<
  *   string,
  *   {
@@ -11,19 +11,21 @@ import { getEmoji } from "./emoji.js";
  *     scripts: Set<string>,
  *     css: Set<string>,
  *     modules: Set<string>,
+ *     links: boolean,
  *   }
  * >}
  */
 export const pageDeps = new Map();
 
 /**
- * @typedef {Record<string, string[]> & {pagePath: string}} PageDeps
+ * @typedef {Record<string, string[] | boolean> & {pagePath: string}} PageDeps
  * @property {string} pagePath Path to the HTML page.
  * @property {string[]} [templatesUsed] Template files referenced by the page.
  * @property {string[]} [svgsUsed] SVG files referenced by the page.
  * @property {string[]} [scriptsUsed] Inline script files referenced by the page.
  * @property {string[]} [cssUsed] CSS files referenced by the page.
  * @property {string[]} [modulesUsed] External module scripts referenced by the page.
+ * @property {boolean} [linksUsed] Whether the page includes `[links]` front matter.
  */
 
 /**
@@ -39,6 +41,7 @@ export function recordPageDeps({
   scriptsUsed = [],
   cssUsed = [],
   modulesUsed = [],
+  linksUsed = false,
 }) {
   if (pagePath === undefined) {
     throw new Error(`no argument passed to recordPageDeps`);
@@ -49,6 +52,7 @@ export function recordPageDeps({
     scripts: new Set(scriptsUsed),
     css: new Set(cssUsed),
     modules: new Set(modulesUsed),
+    links: linksUsed,
   });
 }
 
@@ -168,6 +172,19 @@ export function pagesUsingModule(modulePath) {
   }
   for (const [page, { modules }] of pageDeps) {
     if (modules.has(realPath)) out.push(page);
+  }
+  return out;
+}
+
+/**
+ * Get a list of pages that declare `[links]` front matter.
+ *
+ * @returns {string[]} Array of page paths with link metadata.
+ */
+export function pagesWithLinks() {
+  const out = [];
+  for (const [page, { links }] of pageDeps) {
+    if (links) out.push(page);
   }
   return out;
 }

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -16,6 +16,7 @@ import { markdownToHTML } from "./markdown.js";
  * @property {string[]} scriptsUsed Inline script files referenced by the page.
  * @property {string[]} cssUsed CSS files referenced by the page.
  * @property {string[]} modulesUsed External module scripts referenced by the page.
+ * @property {boolean} linksUsed Whether the page includes `[links]` front matter.
  */
 
 /**
@@ -93,7 +94,8 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const linksManager = new LinksManager(join(siteDir, "links.json"));
     await linksManager.load();
     const rel = relative(siteDir, path).replace(/\\/g, "/");
-    if (Object.keys(page.links).length > 0) {
+    const hasLinks = Object.keys(page.links).length > 0;
+    if (hasLinks) {
       const href = toHref(rel, pretty);
       const changed = linksManager.merge(href, page.links);
       if (changed) await linksManager.save();
@@ -178,6 +180,7 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       scriptsUsed,
       cssUsed,
       modulesUsed,
+      linksUsed: hasLinks,
     };
   } catch (err) {
     if (err instanceof Error) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,10 +1,11 @@
 import { fromFileUrl } from "@std/path";
 import {
+  pagesUsingCss,
+  pagesUsingModule,
   pagesUsingScript,
   pagesUsingSvg,
   pagesUsingTemplate,
-  pagesUsingCss,
-  pagesUsingModule,
+  pagesWithLinks,
   recordPageDeps,
 } from "./page-deps.js";
 import {
@@ -78,7 +79,9 @@ let workerPool;
  * @returns {void}
  */
 function workerRenderPage(path) {
-  workerPool.push({ type: "render", path }, [(e) => recordPageDeps(e.data.deps)]);
+  workerPool.push({ type: "render", path }, [
+    (e) => recordPageDeps(e.data.deps),
+  ]);
 }
 
 /**
@@ -104,16 +107,18 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
   try {
     await Deno.mkdir(templates);
   } catch (exitErr) {
-    console.log(`${getEmoji("warning")} CREATE DIR /template/ -- no need it exists`);
+    console.log(
+      `${getEmoji("warning")} CREATE DIR /template/ -- no need it exists`,
+    );
   }
 
-  const srcWatcher = Deno.watchFs(src, { recursive: true })
+  const srcWatcher = Deno.watchFs(src, { recursive: true });
   console.log(`${getEmoji("success")} CREATING WATCHER /src/`);
- 
-  const templatesWatcher = Deno.watchFs(templates, { recursive: true }); 
+
+  const templatesWatcher = Deno.watchFs(templates, { recursive: true });
   console.log(`${getEmoji("success")} CREATED WATCHER /templates/`);
-  
-  const watchers = [ srcWatcher, templatesWatcher ];
+
+  const watchers = [srcWatcher, templatesWatcher];
 
   const queue = [];
   let timer;
@@ -132,7 +137,7 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
       const kind = classifyPath(path);
       if (evtKind === "create" || evtKind === "modify") {
         if (kind === "PAGE_HTML") {
-          workerRenderPage(path); 
+          workerRenderPage(path);
         } else if (kind === "TEMPLATE") {
           console.log(`${getEmoji("update")} TEMPLATE UPDATED -- ${path}`);
           for (const page of pagesUsingTemplate(path)) {
@@ -158,6 +163,21 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
           const pages = pagesUsingSvg(path);
           if (pages.length === 0) {
             console.log(`  ${getEmoji("warning")} no pages reference this SVG`);
+          } else {
+            for (const page of pages) {
+              workerRenderPage(page);
+            }
+            console.log(
+              `  ${getEmoji("update")} ${pages.length} page(s) updated`,
+            );
+          }
+        } else if (kind === "LINKS_JSON") {
+          console.log(`${getEmoji("update")} LINKS UPDATED -- ${path}`);
+          const pages = pagesWithLinks();
+          if (pages.length === 0) {
+            console.log(
+              `  ${getEmoji("warning")} no pages reference this links.json`,
+            );
           } else {
             for (const page of pages) {
               workerRenderPage(page);
@@ -209,6 +229,11 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
         } else if (kind === "TEMPLATE") {
           console.log(`${getEmoji("delete")} TEMPLATE REMOVED -- ${path}`);
           for (const page of pagesUsingTemplate(path)) {
+            workerRenderPage(page);
+          }
+        } else if (kind === "LINKS_JSON") {
+          console.log(`${getEmoji("delete")} LINKS REMOVED -- ${path}`);
+          for (const page of pagesWithLinks()) {
             workerRenderPage(page);
           }
         }

--- a/lib/watch.test.js
+++ b/lib/watch.test.js
@@ -1,10 +1,10 @@
 import { classifyPath, reduceEvents } from "./fs-utils.js";
 import {
+  clearPageDeps,
   pagesUsingCss,
   pagesUsingModule,
-  recordPageDeps,
-  clearPageDeps,
   pagesUsingTemplate,
+  recordPageDeps,
 } from "./page-deps.js";
 import { renderPage } from "./render-page.js";
 import { join, toFileUrl } from "@std/path";
@@ -39,15 +39,22 @@ function denoTest() {
     assertEquals(classifyPath("/src/site/foo.inline.js"), "JS_INLINE");
     assertEquals(classifyPath("/src/site/js/app.js"), "ASSET");
     assertEquals(classifyPath("/src/site/media/logo.png"), "ASSET");
+    assertEquals(classifyPath("/src/site/links.json"), "LINKS_JSON");
   });
 
   Deno.test("pagesUsingTemplate resolves core and project overrides", () => {
     clearPageDeps();
     const page = "/tmp/page.html";
-    recordPageDeps({pagePath: page, templatesUsed: ["/core/templates/head/default.js"]});
+    recordPageDeps({
+      pagePath: page,
+      templatesUsed: ["/core/templates/head/default.js"],
+    });
     assertEquals(pagesUsingTemplate("/templates/head/default.js"), [page]);
     clearPageDeps();
-    recordPageDeps({ pagePath:page, templatesUsed:["/templates/head/default.js"]});
+    recordPageDeps({
+      pagePath: page,
+      templatesUsed: ["/templates/head/default.js"],
+    });
     assertEquals(pagesUsingTemplate("/core/templates/head/default.js"), [page]);
   });
 
@@ -73,8 +80,8 @@ function denoTest() {
         'title = "Home"',
         'templates.head = "base"',
         'css = ["style.css"]',
-        '#---#',
-        '<h1>hi</h1>',
+        "#---#",
+        "<h1>hi</h1>",
       ].join("\n"),
     );
     const deps1 = await renderPage(pagePath, toFileUrl(root + "/"));
@@ -113,8 +120,8 @@ function denoTest() {
         'title = "Home"',
         'templates.head = "base"',
         'scripts.modules = ["mod.js"]',
-        '#---#',
-        '<h1>hi</h1>',
+        "#---#",
+        "<h1>hi</h1>",
       ].join("\n"),
     );
     const deps1 = await renderPage(pagePath, toFileUrl(root + "/"));

--- a/tests/watch-links.test.js
+++ b/tests/watch-links.test.js
@@ -1,0 +1,82 @@
+import { renderPage } from "../lib/render-page.js";
+import {
+  clearPageDeps,
+  pagesWithLinks,
+  recordPageDeps,
+} from "../lib/page-deps.js";
+import { classifyPath, reduceEvents } from "../lib/fs-utils.js";
+import { join, toFileUrl } from "@std/path";
+
+/**
+ * Simple assertion helper.
+ * @param {unknown} cond Condition expected to be truthy.
+ * @param {string} [msg] Optional assertion message.
+ */
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+
+Deno.test("watch re-renders pages when links.json changes", async () => {
+  clearPageDeps();
+  const rootDir = await Deno.makeTempDir();
+  const rootUrl = toFileUrl(rootDir + "/");
+  const siteDir = await Deno.makeTempDir();
+  const distDir = await Deno.makeTempDir();
+
+  await Deno.writeTextFile(
+    join(siteDir, "config.json"),
+    JSON.stringify({ distantDirectory: distDir }),
+  );
+
+  await Deno.mkdir(join(rootDir, "templates", "head"), { recursive: true });
+  await Deno.writeTextFile(
+    join(rootDir, "templates", "head", "default.js"),
+    "export function render() { return `<title>Watch</title>`; }",
+  );
+  await Deno.mkdir(join(rootDir, "templates", "nav"), { recursive: true });
+  await Deno.writeTextFile(
+    join(rootDir, "templates", "nav", "default.js"),
+    "export function render({ links }) { return `<nav>${links.nav.map(l=>l.label).join(',')}</nav>`; }",
+  );
+
+  const pagePath = join(siteDir, "index.html");
+  const page =
+    `title = "Watch"\n[templates]\nhead = "default"\nnav = "default"\n[links.nav]\nlabel = "Home"\ntopLevel = true\n#---#\n<body></body>`;
+  await Deno.writeTextFile(pagePath, page);
+
+  let deps = await renderPage(pagePath, rootUrl);
+  if (deps) recordPageDeps(deps);
+
+  const outPath = join(distDir, "index.html");
+  let html = await Deno.readTextFile(outPath);
+  assert(html.includes("<nav>Home</nav>"));
+
+  const linksPath = join(siteDir, "links.json");
+  const links = JSON.parse(await Deno.readTextFile(linksPath));
+  links.nav.push({ href: "/about.html", label: "About" });
+  await Deno.writeTextFile(linksPath, JSON.stringify(links, null, 2));
+
+  const events = [{ kind: "modify", paths: [linksPath] }];
+  const paths = reduceEvents(events);
+  const tasks = [];
+  for (const [path, evtKind] of paths) {
+    const kind = classifyPath(path);
+    if (evtKind !== "remove" && kind === "LINKS_JSON") {
+      for (const page of pagesWithLinks()) {
+        tasks.push(page);
+      }
+    }
+  }
+  assert(tasks.length > 0, "no tasks scheduled");
+  for (const page of tasks) {
+    deps = await renderPage(page, rootUrl);
+    if (deps) recordPageDeps(deps);
+  }
+
+  html = await Deno.readTextFile(outPath);
+  assert(html.includes("<nav>Home,About</nav>"));
+
+  await Deno.remove(rootDir, { recursive: true });
+  await Deno.remove(siteDir, { recursive: true });
+  await Deno.remove(distDir, { recursive: true });
+});


### PR DESCRIPTION
## Summary
- detect `links.json` changes and re-render pages that declare `[links]` front matter
- track link metadata usage in page dependencies
- cover `links.json` watch behaviour with dedicated test

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_68910ff0343883318428653ab327ea09