### PR TITLE
feat: re-render pages on links front matter change

### DIFF
--- a/docs/06-rendering-pipeline.md
+++ b/docs/06-rendering-pipeline.md
@@ -52,9 +52,13 @@ flowchart TD
   the site’s `links.json`.
 - **Deduplication** – Two identical `href`/`label` pairs are collapsed if from
   the same source file. Else an error is thrown.
-
 - The file is written back **only if** its in‑memory representation changed to
   avoid spurious disk writes.
+- When a page modifies the navigation data, all other pages declaring
+  `[links]` are automatically re-rendered so templates see the latest
+  information.
+- `links.json` is **auto‑managed**; manual edits are ignored and will be
+  overwritten on the next page render.
 
 ### 2.3 Apply templates
 

--- a/docs/08-links-schema.md
+++ b/docs/08-links-schema.md
@@ -5,6 +5,10 @@ lives alongside each domain folder. Templates read this file to build `<nav>`
 and `<footer>` elements at render‑time.
 
 > **Path:** `/src/<site>/links.json`
+>
+> This file is **auto-generated** from page front-matter. Editing it manually is
+> discouraged because changes are overwritten the next time any page is
+> rendered.
 
 ---
 
@@ -73,6 +77,8 @@ label = "Blog"
 * Merge happens **before** templates render so they always see the latest map.
 * The file is rewritten to disk only when the in‑memory map changed, reducing
   noisy Git diffs.
+* `links.json` is not watched for changes; update navigation through page
+  front‑matter instead of editing the file directly.
 
 <!-- TODO: expose a CLI `--rebuild-links` flag to regenerate links.json from scratch. -->
 

--- a/docs/09-watch-rules.md
+++ b/docs/09-watch-rules.md
@@ -60,6 +60,10 @@ We reduce _raw events_ to _logical events_ with two rules:
 \* SVG files **outside** `src-svg/` are treated as binary assets, **not**
 inlined.
 
+`links.json` itself is not watched. Navigation is updated by editing page
+front‑matter; when a page’s `[links]` data changes, all other pages declaring
+links are re-rendered to stay in sync.
+
 Inline script files (`.inline.js`) trigger `renderAllUsingScript` to re-render
 any pages that include them.
 

--- a/lib/page-deps.js
+++ b/lib/page-deps.js
@@ -11,27 +11,27 @@ import { getEmoji } from "./emoji.js";
  *     scripts: Set<string>,
  *     css: Set<string>,
  *     modules: Set<string>,
- *     links: boolean,
+ *     links?: import("./links.js").PageLinks,
  *   }
  * >}
  */
 export const pageDeps = new Map();
 
 /**
- * @typedef {Record<string, string[] | boolean> & {pagePath: string}} PageDeps
+ * @typedef {Record<string, string[]> & {pagePath: string, links?: import("./links.js").PageLinks}} PageDeps
  * @property {string} pagePath Path to the HTML page.
  * @property {string[]} [templatesUsed] Template files referenced by the page.
  * @property {string[]} [svgsUsed] SVG files referenced by the page.
  * @property {string[]} [scriptsUsed] Inline script files referenced by the page.
  * @property {string[]} [cssUsed] CSS files referenced by the page.
  * @property {string[]} [modulesUsed] External module scripts referenced by the page.
- * @property {boolean} [linksUsed] Whether the page includes `[links]` front matter.
- */
+ * @property {import("./links.js").PageLinks} [links] Page links from front matter.
+*/
 
 /**
  * Record the dependencies used when rendering a page.
  *
- * @param {Record<string, string[]> & {pagePath: string}} deps See {@link PageDeps} for property descriptions.
+ * @param {Record<string, string[]> & {pagePath: string, links?: import("./links.js").PageLinks}} deps See {@link PageDeps} for property descriptions.
  * @returns {void}
  */
 export function recordPageDeps({
@@ -41,7 +41,7 @@ export function recordPageDeps({
   scriptsUsed = [],
   cssUsed = [],
   modulesUsed = [],
-  linksUsed = false,
+  links,
 }) {
   if (pagePath === undefined) {
     throw new Error(`no argument passed to recordPageDeps`);
@@ -52,7 +52,7 @@ export function recordPageDeps({
     scripts: new Set(scriptsUsed),
     css: new Set(cssUsed),
     modules: new Set(modulesUsed),
-    links: linksUsed,
+    links,
   });
 }
 
@@ -184,7 +184,7 @@ export function pagesUsingModule(modulePath) {
 export function pagesWithLinks() {
   const out = [];
   for (const [page, { links }] of pageDeps) {
-    if (links) out.push(page);
+    if (links && Object.keys(links).length > 0) out.push(page);
   }
   return out;
 }

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -17,6 +17,8 @@ import { markdownToHTML } from "./markdown.js";
  * @property {string[]} cssUsed CSS files referenced by the page.
  * @property {string[]} modulesUsed External module scripts referenced by the page.
  * @property {boolean} linksUsed Whether the page includes `[links]` front matter.
+ * @property {boolean} linksChanged Whether `links.json` was updated.
+ * @property {import("./links.js").PageLinks} [links] Page links from front matter.
  */
 
 /**
@@ -95,10 +97,11 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     await linksManager.load();
     const rel = relative(siteDir, path).replace(/\\/g, "/");
     const hasLinks = Object.keys(page.links).length > 0;
+    let linksChanged = false;
     if (hasLinks) {
       const href = toHref(rel, pretty);
-      const changed = linksManager.merge(href, page.links);
-      if (changed) await linksManager.save();
+      linksChanged = linksManager.merge(href, page.links);
+      if (linksChanged) await linksManager.save();
     }
 
     const parser = new DOMParser();
@@ -181,6 +184,8 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       cssUsed,
       modulesUsed,
       linksUsed: hasLinks,
+      linksChanged,
+      links: page.links,
     };
   } catch (err) {
     if (err instanceof Error) {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -29,7 +29,16 @@ let workerPool;
  */
 function workerRenderPage(path) {
   workerPool.push({ type: "render", path }, [
-    (e) => recordPageDeps(e.data.deps),
+    (e) => {
+      const deps = e.data.deps;
+      recordPageDeps(deps);
+      // If navigation data changed, refresh other pages that reference links.json.
+      if (deps && deps.linksChanged) {
+        for (const page of pagesWithLinks()) {
+          if (page !== deps.pagePath) workerRenderPage(page);
+        }
+      }
+    },
   ]);
 }
 
@@ -120,21 +129,6 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
               `  ${getEmoji("update")} ${pages.length} page(s) updated`,
             );
           }
-        } else if (kind === "LINKS_JSON") {
-          console.log(`${getEmoji("update")} LINKS UPDATED -- ${path}`);
-          const pages = pagesWithLinks();
-          if (pages.length === 0) {
-            console.log(
-              `  ${getEmoji("warning")} no pages reference this links.json`,
-            );
-          } else {
-            for (const page of pages) {
-              workerRenderPage(page);
-            }
-            console.log(
-              `  ${getEmoji("update")} ${pages.length} page(s) updated`,
-            );
-          }
         } else if (kind === "ASSET") {
           workerPool.push(`asset:${path}`, { type: "asset", path });
           const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
@@ -178,11 +172,6 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
         } else if (kind === "TEMPLATE") {
           console.log(`${getEmoji("delete")} TEMPLATE REMOVED -- ${path}`);
           for (const page of pagesUsingTemplate(path)) {
-            workerRenderPage(page);
-          }
-        } else if (kind === "LINKS_JSON") {
-          console.log(`${getEmoji("delete")} LINKS REMOVED -- ${path}`);
-          for (const page of pagesWithLinks()) {
             workerRenderPage(page);
           }
         }

--- a/tests/watch-links.test.js
+++ b/tests/watch-links.test.js
@@ -7,76 +7,124 @@ import {
 import { classifyPath, reduceEvents } from "../lib/fs-utils.js";
 import { join, toFileUrl } from "@std/path";
 
-/**
- * Simple assertion helper.
- * @param {unknown} cond Condition expected to be truthy.
- * @param {string} [msg] Optional assertion message.
- */
 function assert(cond, msg = "Assertion failed") {
   if (!cond) throw new Error(msg);
 }
 
-Deno.test("watch re-renders pages when links.json changes", async () => {
-  clearPageDeps();
-  const rootDir = await Deno.makeTempDir();
-  const rootUrl = toFileUrl(rootDir + "/");
-  const siteDir = await Deno.makeTempDir();
-  const distDir = await Deno.makeTempDir();
+Deno.test(
+  "manual links.json edits ignored; front-matter changes rerender dependents",
+  async () => {
+    clearPageDeps();
+    const rootDir = await Deno.makeTempDir();
+    const rootUrl = toFileUrl(rootDir + "/");
+    const siteDir = await Deno.makeTempDir();
+    const distDir = await Deno.makeTempDir();
 
-  await Deno.writeTextFile(
-    join(siteDir, "config.json"),
-    JSON.stringify({ distantDirectory: distDir }),
-  );
+    await Deno.writeTextFile(
+      join(siteDir, "config.json"),
+      JSON.stringify({ distantDirectory: distDir }),
+    );
 
-  await Deno.mkdir(join(rootDir, "templates", "head"), { recursive: true });
-  await Deno.writeTextFile(
-    join(rootDir, "templates", "head", "default.js"),
-    "export function render() { return `<title>Watch</title>`; }",
-  );
-  await Deno.mkdir(join(rootDir, "templates", "nav"), { recursive: true });
-  await Deno.writeTextFile(
-    join(rootDir, "templates", "nav", "default.js"),
-    "export function render({ links }) { return `<nav>${links.nav.map(l=>l.label).join(',')}</nav>`; }",
-  );
+    await Deno.mkdir(join(rootDir, "templates", "head"), { recursive: true });
+    await Deno.writeTextFile(
+      join(rootDir, "templates", "head", "default.js"),
+      "export function render() { return `<title>Watch</title>`; }",
+    );
+    await Deno.mkdir(join(rootDir, "templates", "nav"), { recursive: true });
+    await Deno.writeTextFile(
+      join(rootDir, "templates", "nav", "default.js"),
+      "export function render({ links }) { return `<nav>${links.nav.map(l=>l.label).join(',')}</nav>`; }",
+    );
 
-  const pagePath = join(siteDir, "index.html");
-  const page =
-    `title = "Watch"\n[templates]\nhead = "default"\nnav = "default"\n[links.nav]\nlabel = "Home"\ntopLevel = true\n#---#\n<body></body>`;
-  await Deno.writeTextFile(pagePath, page);
+    const indexPath = join(siteDir, "index.html");
+    const indexPage = [
+      'title = "Watch"',
+      '[templates]',
+      'head = "default"',
+      'nav = "default"',
+      '[links.nav]',
+      'label = "Home"',
+      'topLevel = true',
+      '#---#',
+      '<body></body>',
+    ].join("\n");
+    await Deno.writeTextFile(indexPath, indexPage);
 
-  let deps = await renderPage(pagePath, rootUrl);
-  if (deps) recordPageDeps(deps);
+    const aboutPath = join(siteDir, "about.html");
+    const aboutPage = [
+      'title = "About"',
+      '[templates]',
+      'head = "default"',
+      'nav = "default"',
+      '[links.nav]',
+      'label = "About"',
+      '#---#',
+      '<body></body>',
+    ].join("\n");
+    await Deno.writeTextFile(aboutPath, aboutPage);
 
-  const outPath = join(distDir, "index.html");
-  let html = await Deno.readTextFile(outPath);
-  assert(html.includes("<nav>Home</nav>"));
+    // Initial render of both pages
+    for (const p of [indexPath, aboutPath]) {
+      const deps = await renderPage(p, rootUrl);
+      if (deps) recordPageDeps(deps);
+    }
 
-  const linksPath = join(siteDir, "links.json");
-  const links = JSON.parse(await Deno.readTextFile(linksPath));
-  links.nav.push({ href: "/about.html", label: "About" });
-  await Deno.writeTextFile(linksPath, JSON.stringify(links, null, 2));
+    let aboutHtml = await Deno.readTextFile(join(distDir, "about.html"));
+    assert(aboutHtml.includes("<nav>Home,About</nav>"));
 
-  const events = [{ kind: "modify", paths: [linksPath] }];
-  const paths = reduceEvents(events);
-  const tasks = [];
-  for (const [path, evtKind] of paths) {
-    const kind = classifyPath(path);
-    if (evtKind !== "remove" && kind === "LINKS_JSON") {
-      for (const page of pagesWithLinks()) {
-        tasks.push(page);
+    // Manually edit links.json and ensure no re-render tasks are scheduled
+    const linksPath = join(siteDir, "links.json");
+    const links = JSON.parse(await Deno.readTextFile(linksPath));
+    links.nav[0].label = "Manual";
+    await Deno.writeTextFile(linksPath, JSON.stringify(links, null, 2));
+
+    const events = [{ kind: "modify", paths: [linksPath] }];
+    const paths = reduceEvents(events);
+    const tasks = [];
+    for (const [p, evtKind] of paths) {
+      const kind = classifyPath(p);
+      if (evtKind !== "remove") {
+        if (kind === "PAGE_HTML") tasks.push(p);
+        // no branch for LINKS_JSON
       }
     }
-  }
-  assert(tasks.length > 0, "no tasks scheduled");
-  for (const page of tasks) {
-    deps = await renderPage(page, rootUrl);
-    if (deps) recordPageDeps(deps);
-  }
+    assert(tasks.length === 0, "links.json edit triggered tasks");
 
-  html = await Deno.readTextFile(outPath);
-  assert(html.includes("<nav>Home,About</nav>"));
+    aboutHtml = await Deno.readTextFile(join(distDir, "about.html"));
+    assert(aboutHtml.includes("<nav>Home,About</nav>"));
 
-  await Deno.remove(rootDir, { recursive: true });
-  await Deno.remove(siteDir, { recursive: true });
-  await Deno.remove(distDir, { recursive: true });
-});
+    // Change front-matter label and trigger dependent re-renders
+    const updatedIndex = [
+      'title = "Watch"',
+      '[templates]',
+      'head = "default"',
+      'nav = "default"',
+      '[links.nav]',
+      'label = "Start"',
+      'topLevel = true',
+      '#---#',
+      '<body></body>',
+    ].join("\n");
+    await Deno.writeTextFile(indexPath, updatedIndex);
+
+    let deps = await renderPage(indexPath, rootUrl);
+    if (deps) {
+      recordPageDeps(deps);
+      if (deps.linksChanged) {
+        for (const page of pagesWithLinks()) {
+          if (page !== indexPath) {
+            const d = await renderPage(page, rootUrl);
+            if (d) recordPageDeps(d);
+          }
+        }
+      }
+    }
+
+    aboutHtml = await Deno.readTextFile(join(distDir, "about.html"));
+    assert(aboutHtml.includes("<nav>Start,About</nav>"));
+
+    await Deno.remove(rootDir, { recursive: true });
+    await Deno.remove(siteDir, { recursive: true });
+    await Deno.remove(distDir, { recursive: true });
+  },
+);


### PR DESCRIPTION
## Summary
- stop watching `links.json` directly and instead use `linksChanged` flag to trigger dependent re-renders
- track per-page link metadata so changes are detectable
- clarify that `links.json` is auto-managed and should not be edited by hand

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_6891271a8ce48331a4a8695a1c9e43dd