### PR TITLE
Prune stale links from links.json

### DIFF
--- a/docs/08-links-schema.md
+++ b/docs/08-links-schema.md
@@ -16,24 +16,24 @@ and `<footer>` elements at render‑time.
 
 ```jsonc
 {
-  "nav": [               // array – order is preserved
-    { "topLevel": true, "href": "/",      "label": "Home" },
+  "nav": [ // array – order is preserved
+    { "topLevel": true, "href": "/", "label": "Home" },
     { "subLevel": "docs", "href": "/docs/intro.html", "label": "Docs" }
   ],
-  "footer": [           // array – grouped into columns by template logic
+  "footer": [ // array – grouped into columns by template logic
     { "column": "company", "href": "/about.html", "label": "About" },
-    { "column": "legal",   "href": "/terms.html", "label": "Terms" }
+    { "column": "legal", "href": "/terms.html", "label": "Terms" }
   ]
 }
 ```
 
-* **`nav` array**
+- **`nav` array**
 
-  * **Top‑level item** → object with `topLevel: true`.
-  * **Sub‑level item** → object with `subLevel: "<bucket>"`.
-* **`footer` array**
+  - **Top‑level item** → object with `topLevel: true`.
+  - **Sub‑level item** → object with `subLevel: "<bucket>"`.
+- **`footer` array**
 
-  * Items carry a `column: "<bucket>"` property.
+  - Items carry a `column: "<bucket>"` property.
 
 > The build **does not** restrict buckets to a predefined list—templates decide
 > how to group/sort them.
@@ -46,9 +46,9 @@ and `<footer>` elements at render‑time.
 | ---------- | ------------ | ------- | -------- | --------------------------------------------------------------------- |
 | `href`     | nav & footer | string  | **Yes**  | Absolute or root‑relative path.                                       |
 | `label`    | nav & footer | string  | **Yes**  | Text visible in menu.                                                 |
-| `topLevel` | nav          | boolean | ⬜        | Marks item as a first‑level link. Mutually exclusive with `subLevel`. |
-| `subLevel` | nav          | string  | ⬜        | Bucket name for nested menu.                                          |
-| `column`   | footer       | string  | ⬜        | Column bucket name.                                                   |
+| `topLevel` | nav          | boolean | ⬜       | Marks item as a first‑level link. Mutually exclusive with `subLevel`. |
+| `subLevel` | nav          | string  | ⬜       | Bucket name for nested menu.                                          |
+| `column`   | footer       | string  | ⬜       | Column bucket name.                                                   |
 
 <!-- TODO: consider allowing `target:"_blank"`, `rel:"noopener"` for external links. -->
 
@@ -64,8 +64,8 @@ and `<footer>` elements at render‑time.
 
 ## 3. How links are **added & merged**
 
-When a page has `[links]` keys in its front‑matter (see **04‑front‑matter**), the
-renderer merges a new object into the array:
+When a page has `[links]` keys in its front‑matter (see **04‑front‑matter**),
+the renderer merges a new object into the array:
 
 ```toml
 [links.nav]
@@ -73,11 +73,13 @@ topLevel = true
 label = "Blog"
 ```
 
-* If a nav item with the **same `href`** already exists, its `label` is updated.
-* Merge happens **before** templates render so they always see the latest map.
-* The file is rewritten to disk only when the in‑memory map changed, reducing
+- If a nav item with the **same `href`** already exists, its `label` is updated.
+- Omitting `[links.nav]`, `[links.footer]`, or the entire `[links]` table
+  automatically prunes any existing entry for that page.
+- Merge happens **before** templates render so they always see the latest map.
+- The file is rewritten to disk only when the in‑memory map changed, reducing
   noisy Git diffs.
-* `links.json` is not watched for changes; update navigation through page
+- `links.json` is not watched for changes; update navigation through page
   front‑matter instead of editing the file directly.
 
 <!-- TODO: expose a CLI `--rebuild-links` flag to regenerate links.json from scratch. -->
@@ -105,8 +107,8 @@ tests.
           { "required": ["subLevel"], "not": { "required": ["topLevel"] } }
         ],
         "properties": {
-          "href":   { "type": "string" },
-          "label":  { "type": "string" },
+          "href": { "type": "string" },
+          "label": { "type": "string" },
           "topLevel": { "type": "boolean" },
           "subLevel": { "type": "string" }
         },
@@ -119,8 +121,8 @@ tests.
         "type": "object",
         "required": ["href", "label", "column"],
         "properties": {
-          "href":   { "type": "string" },
-          "label":  { "type": "string" },
+          "href": { "type": "string" },
+          "label": { "type": "string" },
           "column": { "type": "string" }
         },
         "additionalProperties": false
@@ -141,4 +143,3 @@ and be announced in `CHANGELOG.md`.
 ---
 
 ### Next → [09-watch-rules](09-watch-rules.md)
-

--- a/lib/links.js
+++ b/lib/links.js
@@ -78,6 +78,13 @@ export class LinksManager {
         this.data.nav.push(item);
         changed = true;
       }
+    } else {
+      // Remove existing nav entry when the page omits `[links.nav]`.
+      const idx = this.data.nav.findIndex((l) => l.href === href);
+      if (idx >= 0) {
+        this.data.nav.splice(idx, 1);
+        changed = true;
+      }
     }
     if (pageLinks.footer) {
       const item = { href, label: pageLinks.footer.label };
@@ -93,6 +100,13 @@ export class LinksManager {
         }
       } else {
         this.data.footer.push(item);
+        changed = true;
+      }
+    } else {
+      // Remove existing footer entry when the page omits `[links.footer]`.
+      const idx = this.data.footer.findIndex((l) => l.href === href);
+      if (idx >= 0) {
+        this.data.footer.splice(idx, 1);
         changed = true;
       }
     }

--- a/lib/links.test.js
+++ b/lib/links.test.js
@@ -39,4 +39,52 @@ Deno.test("LinksManager merges links and writes only when changed", async () => 
   data = JSON.parse(text);
   assertEquals(data.nav.length, 1);
   assertEquals(data.nav[0].label, "About Us");
+
+  lm.merge("/contact.html", {
+    footer: { column: "company", label: "Reach Us" },
+  });
+  await lm.save();
+  text = await Deno.readTextFile(path);
+  data = JSON.parse(text);
+  assertEquals(data.footer.length, 1);
+  assertEquals(data.footer[0].label, "Reach Us");
+});
+
+Deno.test("LinksManager removes links when sections are omitted", async () => {
+  const dir = await Deno.makeTempDir();
+  const path = `${dir}/links.json`;
+  await Deno.writeTextFile(
+    path,
+    JSON.stringify({ nav: [], footer: [] }, null, 2) + "\n",
+  );
+
+  const lm = new LinksManager(path);
+  await lm.load();
+
+  // Add navigation and footer entries for a page.
+  lm.merge("/about.html", {
+    nav: { topLevel: true, label: "About" },
+    footer: { column: "company", label: "About" },
+  });
+  await lm.save();
+
+  // Page now omits the nav link but keeps the footer entry.
+  lm.merge("/about.html", {
+    footer: { column: "company", label: "About" },
+  });
+  await lm.save();
+
+  let text = await Deno.readTextFile(path);
+  let data = JSON.parse(text);
+  assertEquals(data.nav.length, 0);
+  assertEquals(data.footer.length, 1);
+
+  // Page removes the entire `[links]` section.
+  lm.merge("/about.html", {});
+  await lm.save();
+
+  text = await Deno.readTextFile(path);
+  data = JSON.parse(text);
+  assertEquals(data.nav.length, 0);
+  assertEquals(data.footer.length, 0);
 });

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -96,13 +96,11 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     const linksManager = new LinksManager(join(siteDir, "links.json"));
     await linksManager.load();
     const rel = relative(siteDir, path).replace(/\\/g, "/");
-    const hasLinks = Object.keys(page.links).length > 0;
-    let linksChanged = false;
-    if (hasLinks) {
-      const href = toHref(rel, pretty);
-      linksChanged = linksManager.merge(href, page.links);
-      if (linksChanged) await linksManager.save();
-    }
+    const href = toHref(rel, pretty);
+    const linksUsed = page.frontMatter.links !== undefined;
+    // Always merge so links are pruned when omitted from the page.
+    const linksChanged = linksManager.merge(href, page.links ?? {});
+    if (linksChanged) await linksManager.save();
 
     const parser = new DOMParser();
     const docString = `<html><head></head><body>${page.html}</body></html>`;
@@ -183,7 +181,7 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       scriptsUsed,
       cssUsed,
       modulesUsed,
-      linksUsed: hasLinks,
+      linksUsed,
       linksChanged,
       links: page.links,
     };


### PR DESCRIPTION
## Summary
- delete nav/footer entries for pages that no longer define them
- always merge page links to enable pruning when `[links]` is missing
- document automatic link pruning and extend tests for add/update/delete

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68912ad94320833186fce52c50948e41