### PR TITLE
feat: add css fallback support

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -1,0 +1,4 @@
+/* Default fallback stylesheet */
+body {
+  margin: 0;
+}

--- a/docs/02-directory-layout.md
+++ b/docs/02-directory-layout.md
@@ -54,10 +54,13 @@ project-root/
 2. **Templates are global.** All sites pull from the same `/templates` pool, but
    the folder may be omitted—matching files from `/core/templates` are used
    instead.
-3. **Sub‑folders allowed.** Inside any site, you can nest pages arbitrarily
+3. **Styles can fall back to core.** If a stylesheet referenced by a page is
+   missing under the site folder, a file with the same path from `/core/css/`
+   is used instead.
+4. **Sub‑folders allowed.** Inside any site, you can nest pages arbitrarily
    (e.g. `docs/getting-started.html`) – the relative path is preserved in the
    build output.
-4. **`src-svg/` is special.** SVGs stored here are inlined by the generator when
+5. **`src-svg/` is special.** SVGs stored here are inlined by the generator when
    referenced via `<icon>` or `<logo>` tags.
 
 ---

--- a/docs/10-file-copy-rules.md
+++ b/docs/10-file-copy-rules.md
@@ -41,6 +41,13 @@ extend via a future config key.
 Inline JavaScript (`.inline.js`) files are intentionally excluded—they are
 inlined into HTML pages instead of being copied.
 
+### CSS fallbacks
+
+If a referenced stylesheet is missing from the site folder, Kobra Kreator looks
+for a file with the same relative path under `/core/css/`. When found, that
+fallback is copied to the destination. If no such file exists, an error is
+logged but the watcher continues running.
+
 ---
 
 ## 3. Copy triggers

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -1,6 +1,7 @@
-import { basename, dirname, join, relative } from "@std/path";
+import { basename, dirname, join, relative, fromFileUrl } from "@std/path";
 import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
 import { hashAssetName } from "./hash-asset.js";
+import { getEmoji } from "./emoji.js";
 
 /**
  * Copy an asset from the source tree to its distant output directory.
@@ -24,11 +25,33 @@ export async function copyAsset(path) {
   const configText = await Deno.readTextFile(configPath);
   const config = JSON.parse(configText);
   const distant = String(config.distantDirectory);
+
+  let srcPath = path;
+  try {
+    await Deno.stat(srcPath);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound && ext === ".css") {
+      const fallback = fromFileUrl(new URL(`../core/css/${rel}`, import.meta.url));
+      try {
+        await Deno.stat(fallback);
+        srcPath = fallback;
+      } catch (err2) {
+        if (err2 instanceof Deno.errors.NotFound) {
+          console.log(`${getEmoji("error")} CSS missing -- ${rel}`);
+          return;
+        }
+        throw err2;
+      }
+    } else {
+      throw err;
+    }
+  }
+
   let outRel = rel;
   if (config.hashAssets && (ext === ".css" || ext === ".js")) {
     const dirRel = dirname(rel);
     const base = basename(rel, ext);
-    const hashed = await hashAssetName(path);
+    const hashed = await hashAssetName(srcPath);
     const outDir = join(distant, dirRel);
     // Remove any existing un-hashed asset to avoid stale files.
     const unhashed = join(outDir, `${base}${ext}`);
@@ -58,7 +81,7 @@ export async function copyAsset(path) {
   }
   const outPath = join(distant, outRel);
   await Deno.mkdir(dirname(outPath), { recursive: true });
-  await Deno.copyFile(path, outPath);
+  await Deno.copyFile(srcPath, outPath);
 }
 
 /**

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,5 +1,6 @@
-import { dirname, join, relative, toFileUrl } from "@std/path";
+import { dirname, join, relative, toFileUrl, fromFileUrl } from "@std/path";
 import { hashAssetName } from "./hash-asset.js";
+import { copyAsset } from "./copy-asset.js";
 import { DOMParser } from "@b-fuze/deno-dom";
 import { parsePage } from "./parse-page.js";
 import { LinksManager } from "./links.js";
@@ -56,19 +57,38 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       cssFiles.map(async (href) => {
         const relHref = href.startsWith("/") ? href.slice(1) : href;
         const abs = join(siteDir, relHref);
-        let real;
         try {
-          real = await Deno.realPath(abs);
+          const real = await Deno.realPath(abs);
+          cssUsed.push(real);
+          if (!hashAssets) return href;
+          const hashed = await hashAssetName(real);
+          const dirRel = dirname(relHref);
+          const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+            .replace(/\\/g, "/");
+          return href.startsWith("/") ? "/" + relPath : relPath;
         } catch {
-          real = abs;
+          const corePath = fromFileUrl(
+            new URL(`../core/css/${relHref}`, import.meta.url),
+          );
+          try {
+            await Deno.stat(corePath);
+            cssUsed.push(abs);
+            if (hashAssets) {
+              const hashed = await hashAssetName(corePath);
+              const dirRel = dirname(relHref);
+              const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+                .replace(/\\/g, "/");
+              await copyAsset(abs);
+              return href.startsWith("/") ? "/" + relPath : relPath;
+            }
+            await copyAsset(abs);
+            return href;
+          } catch {
+            console.log(`${getEmoji("error")} CSS missing -- ${relHref}`);
+            cssUsed.push(abs);
+            return href;
+          }
         }
-        cssUsed.push(real);
-        if (!hashAssets) return href;
-        const hashed = await hashAssetName(abs);
-        const dirRel = dirname(relHref);
-        const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-          .replace(/\\/g, "/");
-        return href.startsWith("/") ? "/" + relPath : relPath;
       }),
     );
     const modulesUsed = [];

--- a/tests/css-fallback.test.js
+++ b/tests/css-fallback.test.js
@@ -1,0 +1,66 @@
+import { renderPage } from "../lib/render-page.js";
+import { clearPageDeps } from "../lib/page-deps.js";
+import { join, toFileUrl, fromFileUrl } from "@std/path";
+
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+function assertEquals(a, b) {
+  const da = JSON.stringify(a);
+  const db = JSON.stringify(b);
+  if (da !== db) throw new Error(`Expected ${db}, got ${da}`);
+}
+async function fileExists(path) {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
+  }
+}
+
+Deno.test("renderPage falls back to core css when missing", async () => {
+  clearPageDeps();
+  const root = await Deno.makeTempDir();
+  const rootUrl = toFileUrl(root + "/");
+  const siteDir = join(root, "mysite");
+  const distDir = join(root, "dist");
+  await Deno.mkdir(siteDir, { recursive: true });
+  await Deno.mkdir(distDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(siteDir, "config.json"),
+    JSON.stringify({ distantDirectory: distDir }),
+  );
+  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "head", "default.js"),
+    [
+      "export function render({ frontMatter }) {",
+      '  const cssLinks = (frontMatter.css || []).map((href) => `<link rel=\\"stylesheet\\" href=\\"${href}\\">`).join(\"\");',
+      "  return `<title>${frontMatter.title}</title>${cssLinks}`;",
+      "}",
+    ].join("\n"),
+  );
+  await Deno.writeTextFile(
+    join(root, "templates", "nav", "default.js"),
+    "export function render(){ return `<nav></nav>`; }",
+  );
+  await Deno.writeTextFile(
+    join(root, "templates", "footer", "default.js"),
+    "export function render(){ return `<footer></footer>`; }",
+  );
+  const pagePath = join(siteDir, "index.html");
+  const page =
+    'title = "Home"\ncss = ["styles.css"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n#---#\n<body>hi</body>';
+  await Deno.writeTextFile(pagePath, page);
+  await renderPage(pagePath, rootUrl);
+  const cssOut = join(distDir, "styles.css");
+  assert(await fileExists(cssOut));
+  const outContent = await Deno.readTextFile(cssOut);
+  const coreCss = fromFileUrl(new URL("../core/css/styles.css", import.meta.url));
+  const coreContent = await Deno.readTextFile(coreCss);
+  assertEquals(outContent, coreContent);
+});


### PR DESCRIPTION
## Summary
- copy missing stylesheets from `/core/css` as fallback
- warn with emoji when both site and core stylesheet are missing
- document core CSS fallback behaviour

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_6891a94c5a3883318a11c6892d2ccd44