### PR TITLE
docs: document before/after template slots

### DIFF
--- a/docs/00-roadmap.md
+++ b/docs/00-roadmap.md
@@ -8,6 +8,7 @@ implementation status.
 | Multi‑site build from one repo       | ✅     | Folders in `/src/` for each domain     |
 | Pure Deno runtime                    | ✅     | No Node.js tool‑chain needed           |
 | User Template modules for head/nav/footer | ✅     | Reusable JS `render()` functions       |
+| Before/after template slots               | ✅     | Inject fragments around main content   |
 | Core templates for head/nav/footer   | ✅     | Reusable JS `render()` functions when no user override exists              |
 | Core css for fast start              | ✅     | Reusable css files when no user override exists       |
 | Hot‑reload file watcher              | ✅     | Uses `Deno.watchFs` with debounce      |

--- a/docs/04-front-matter.md
+++ b/docs/04-front-matter.md
@@ -25,7 +25,10 @@ attach, which templates to render, and how to update `links.json`.
 | `css`                   | string\[] | ⬜       | Extra stylesheets. Relative to site root **or** absolute URL (CDN). |
 | `[templates].head`      | string    | ✅       | File name under `templates/head/` (without extension).              |
 | `[templates].nav`       | string    | ⬜       | File name under `templates/nav/`.                                   |
+| `[templates].header`    | string    | ⬜       | File name under `templates/header/`.                                |
 | `[templates].footer`    | string    | ⬜       | File name under `templates/footer/`.                                |
+| `[templates].before`    | table     | ⬜       | Slots rendered **before** main content; each key maps to a template name or `{name, priority}`. |
+| `[templates].after`     | table     | ⬜       | Slots rendered **after** main content; each key maps to a template name or `{name, priority}`. |
 | `[scripts].modules`     | string\[] | ⬜       | Added as `<script type="module" src="…">` _before_ inline scripts.  |
 | `[scripts].inline`      | string\[] | ⬜       | **Filename** to inline (**not** external URL)                       |
 | `[links].nav.topLevel`  | bool      | ⬜       | If `true`, add to `links.json.nav` (top level).                     |
@@ -87,11 +90,25 @@ inline  = ["form.inline.js"]
 
 ---
 
+### Before/after slots
+
+Use `templates.before` and `templates.after` to inject arbitrary fragments around the main content. Each entry maps a slot name to a template file or an object with `name` and optional `priority` (higher numbers render first).
+
+```toml
+[templates.before]
+promo = { name = "promo-banner", priority = 1 }
+
+[templates.after]
+signup = "newsletter"
+```
+
+---
+
 ## Processing order
 
 1. **Parse TOML → JS object.** Invalid TOML throws a build error.
 2. **Update** `links.json` if any `links.*` keys present.
-3. **Template selection** – resolve `head.js`, `nav.js`, `footer.js`.
+3. **Template selection** – resolve `head.js`, `nav.js`, `header.js`, `footer.js`, and any `templates.before/*` or `templates.after/*`.
 4. **Inject CSS & scripts** – module scripts before inline scripts.
 5. **Render** assembled HTML page.
 

--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -3,8 +3,19 @@ import { fromFileUrl } from "@std/path";
 
 /**
  * Dynamically import a template module, with cache-busting and fallback to core templates.
+ *
+ * @param {string} [slot=""] Template slot such as "head" or "footer".
+ * @param {string} [name=""] Template file name without extension.
+ * @param {URL} [root=new URL("..", import.meta.url)] Root directory to resolve templates from.
+ * @param {string[]} [used=[]] Collector for resolved template paths.
+ * @returns {Promise<{render: (ctx: Record<string, unknown>) => string}>} Loaded template module.
  */
-export async function importTemplate(slot, name, root, used) {
+export async function importTemplate(
+  slot = "",
+  name = "",
+  root = new URL("..", import.meta.url),
+  used = [],
+) {
   let moduleUrl = new URL(`templates/${slot}/${name}.js`, root);
   let module;
 
@@ -49,6 +60,8 @@ export async function importTemplate(slot, name, root, used) {
 
 /**
  * Ensure the document has an <html> element.
+ *
+ * @param {Document} doc Document to normalize.
  */
 export function ensureHtmlRoot(doc) {
   if (!doc.documentElement) {
@@ -59,8 +72,23 @@ export function ensureHtmlRoot(doc) {
 
 /**
  * Render a set of templates defined as an object mapping slot->(string|{name,priority}).
+ *
+ * @param {Record<string, string|{name: string, priority?: number}>} [defs={}] Template definitions.
+ * @param {Record<string, unknown>} [frontMatter={}] Front matter for the page.
+ * @param {Record<string, unknown>} [links={}] Link metadata passed to templates.
+ * @param {Record<string, unknown>} [config={}] Build configuration.
+ * @param {URL} [root=new URL("..", import.meta.url)] Project root for template resolution.
+ * @param {string[]} [used=[]] Collector for resolved template paths.
+ * @returns {Promise<Array<{slot: string, html: string, priority: number}>>} Rendered template fragments.
  */
-export async function renderSlots(defs, frontMatter, links, config, root, used) {
+export async function renderSlots(
+  defs = {},
+  frontMatter = {},
+  links = {},
+  config = {},
+  root = new URL("..", import.meta.url),
+  used = [],
+) {
   const parts = [];
 
   for (const [slot, def] of Object.entries(defs)) {
@@ -103,12 +131,19 @@ export async function renderSlots(defs, frontMatter, links, config, root, used) 
  * - frontMatter.templates: fixed slots (head, nav, header, footer)
  * - frontMatter.templates.before: arbitrary slots before main content, ordered by priority
  * - frontMatter.templates.after: arbitrary slots after main content, ordered by priority
+ *
+ * @param {Document} doc Document to mutate.
+ * @param {{frontMatter: Record<string, unknown>, html: string}} page Page object with metadata and HTML.
+ * @param {Record<string, unknown>} [links={}] Link metadata passed to templates.
+ * @param {Record<string, unknown>} [config={}] Build configuration.
+ * @param {URL} [root=new URL("..", import.meta.url)] Root directory to resolve templates from.
+ * @returns {Promise<string[]>} File paths of templates that were used.
  */
 export async function applyTemplates(
   doc,
   page,
-  links,
-  config,
+  links = {},
+  config = {},
   root = new URL("..", import.meta.url),
 ) {
   const { frontMatter, html } = page;


### PR DESCRIPTION
## Summary
- add JSDoc types and defaults to template helpers
- document `templates.before` and `templates.after` front-matter options
- note before/after template support in roadmap

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors` *(fails: modifying module triggers re-render with updated hash, applyTemplates inserts rendered fragments, applyTemplates handles document with no root element, applyTemplates falls back to core templates, applyTemplates errors when template missing in project and core, incremental end-to-end flow, watch processes only whitelisted asset file types, inline scripts are inlined and not copied, renderPage renders page and updates links, renderPage hashes asset references when enabled, watch re-renders pages when inline scripts change)*

------
https://chatgpt.com/codex/tasks/task_e_68925ee26ddc833199fe86f892805a7b