### PR TITLE
Fix render pipeline and update template tests

### DIFF
--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -123,8 +123,9 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
     if (linksChanged) await linksManager.save();
 
     const parser = new DOMParser();
-    const docString = `<html><head></head><body>${page.html}</body></html>`;
-    const doc = parser.parseFromString(docString, "text/html");
+    // Build a minimal document. Templates are responsible for generating
+    // the final <head> and <body> structure.
+    const doc = parser.parseFromString("<html></html>", "text/html");
     if (!doc) throw new Error(`${path}: invalid HTML`);
 
     const templatesUsed = await applyTemplates(
@@ -134,6 +135,9 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       config,
       root,
     );
+
+    const body = doc.querySelector("body");
+    if (!body) throw new Error(`${path}: missing <body> element`);
 
     for (const src of page.scripts.modules ?? []) {
       const script = doc.createElement("script");


### PR DESCRIPTION
## Summary
- ensure `renderPage` builds a minimal document and checks for a body element before injecting scripts
- update template tests for new API and normalized whitespace

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_689262d6c4ac8331b57468bbbb8bc951