### PR TITLE
refactor: share site root discovery

### DIFF
--- a/lib/build-document.js
+++ b/lib/build-document.js
@@ -1,0 +1,73 @@
+import { DOMParser } from "@b-fuze/deno-dom";
+import { applyTemplates } from "./apply-templates.js";
+import { inlineSvg } from "./inline-svg.js";
+import { join, toFileUrl } from "@std/path";
+
+/**
+ * Construct the final DOM document for a page.
+ *
+ * @param {import('./parse-page.js').ParsedPage} page Parsed page object.
+ * @param {import('./links.js').LinksManager} linksManager Links manager with
+ * current data.
+ * @param {Record<string, unknown>} config Site configuration.
+ * @param {URL} root Base URL to resolve template paths.
+ * @param {string} siteDir Site root directory.
+ * @param {string} pagePath Absolute path to the source file, used for errors.
+ * @returns {Promise<{doc: import('@b-fuze/deno-dom').DOMDocument, templatesUsed: string[], scriptsUsed: string[], svgsUsed: string[]}>}
+ * DOM document and dependency information.
+ */
+export async function buildDocument(
+  page,
+  linksManager,
+  config,
+  root,
+  siteDir,
+  pagePath,
+) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("<html></html>", "text/html");
+  if (!doc) throw new Error(`${pagePath}: invalid HTML`);
+
+  const templatesUsed = await applyTemplates(
+    doc,
+    page,
+    linksManager.data,
+    config,
+    root,
+  );
+
+  const body = doc.querySelector("body");
+  if (!body) throw new Error(`${pagePath}: missing <body> element`);
+
+  for (const src of page.scripts.modules ?? []) {
+    const script = doc.createElement("script");
+    script.setAttribute("type", "module");
+    script.setAttribute("src", src);
+    body.appendChild(script);
+  }
+
+  const scriptsUsed = [];
+  for (const file of page.scripts.inline ?? []) {
+    const scriptPath = join(siteDir, file);
+    let realPath;
+    try {
+      realPath = await Deno.realPath(scriptPath);
+    } catch {
+      realPath = scriptPath;
+    }
+    let content;
+    try {
+      content = await Deno.readTextFile(realPath);
+    } catch (err) {
+      if (err instanceof Error) err.message = `${realPath}: ${err.message}`;
+      throw err;
+    }
+    scriptsUsed.push(realPath);
+    const script = doc.createElement("script");
+    script.textContent = content;
+    body.appendChild(script);
+  }
+
+  const svgsUsed = await inlineSvg(doc, toFileUrl(siteDir + "/"));
+  return { doc, templatesUsed, scriptsUsed, svgsUsed };
+}

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -1,7 +1,8 @@
-import { basename, dirname, join, relative, fromFileUrl } from "@std/path";
+import { basename, dirname, fromFileUrl, join, relative } from "@std/path";
 import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
 import { hashAssetName } from "./hash-asset.js";
 import { getEmoji } from "./emoji.js";
+import { findSiteRoot } from "./load-config.js";
 
 /**
  * Copy an asset from the source tree to its distant output directory.
@@ -31,7 +32,9 @@ export async function copyAsset(path) {
     await Deno.stat(srcPath);
   } catch (err) {
     if (err instanceof Deno.errors.NotFound && ext === ".css") {
-      const fallback = fromFileUrl(new URL(`../core/css/${rel}`, import.meta.url));
+      const fallback = fromFileUrl(
+        new URL(`../core/css/${rel}`, import.meta.url),
+      );
       try {
         await Deno.stat(fallback);
         srcPath = fallback;
@@ -133,28 +136,5 @@ export async function removeAsset(path) {
     await Deno.remove(outPath);
   } catch (err) {
     if (!(err instanceof Deno.errors.NotFound)) throw err;
-  }
-}
-
-/**
- * Walk up the directory tree looking for a `config.json` file.
- *
- * @param {string} filePath Path of the file whose site root is required.
- * @returns {Promise<string>} Directory containing the `config.json` file.
- */
-async function findSiteRoot(filePath) {
-  let dir = dirname(filePath);
-  while (true) {
-    try {
-      const stat = await Deno.stat(join(dir, "config.json"));
-      if (stat.isFile) return dir;
-    } catch (err) {
-      if (!(err instanceof Deno.errors.NotFound)) throw err;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) {
-      throw new Error(`config.json not found for ${filePath}`);
-    }
-    dir = parent;
   }
 }

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -1,0 +1,40 @@
+import { dirname, join } from "@std/path";
+
+/**
+ * Load the site configuration for a given source file.
+ *
+ * @param {string} filePath Absolute path to the source file.
+ * @returns {Promise<{siteDir: string, config: Record<string, unknown>}>} Site
+ * root directory and parsed configuration.
+ */
+export async function loadConfig(filePath) {
+  const siteDir = await findSiteRoot(filePath);
+  const configPath = join(siteDir, "config.json");
+  const configText = await Deno.readTextFile(configPath);
+  const config = JSON.parse(configText);
+  return { siteDir, config };
+}
+
+/**
+ * Walk up the directory hierarchy to locate the site root containing
+ * `config.json`.
+ *
+ * @param {string} filePath Path used to search for the site root.
+ * @returns {Promise<string>} Directory path containing `config.json`.
+ */
+export async function findSiteRoot(filePath) {
+  let dir = dirname(filePath);
+  while (true) {
+    try {
+      const stat = await Deno.stat(join(dir, "config.json"));
+      if (stat.isFile) return dir;
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`config.json not found for ${filePath}`);
+    }
+    dir = parent;
+  }
+}

--- a/lib/load-config.test.js
+++ b/lib/load-config.test.js
@@ -1,0 +1,29 @@
+import { join } from "@std/path";
+import { assertEquals, assertRejects } from "https://deno.land/std@0.203.0/testing/asserts.ts";
+import { findSiteRoot } from "./load-config.js";
+
+Deno.test("findSiteRoot - locates nearest config.json", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(join(dir, "config.json"), "{}\n");
+    const nested = join(dir, "a", "b");
+    await Deno.mkdir(nested, { recursive: true });
+    const filePath = join(nested, "file.txt");
+    const root = await findSiteRoot(filePath);
+    assertEquals(root, dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findSiteRoot - errors when config.json missing", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const nested = join(dir, "child");
+    await Deno.mkdir(nested);
+    const filePath = join(nested, "file.txt");
+    await assertRejects(() => findSiteRoot(filePath));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/lib/manage-links.js
+++ b/lib/manage-links.js
@@ -1,0 +1,36 @@
+import { join, relative } from "@std/path";
+import { LinksManager } from "./links.js";
+
+/**
+ * Merge page links into the global links manager.
+ *
+ * @param {import('./parse-page.js').ParsedPage} page Parsed page object.
+ * @param {string} siteDir Site root directory.
+ * @param {string} path Absolute path to the page being rendered.
+ * @param {boolean} pretty Whether to generate pretty URLs.
+ * @returns {Promise<{linksManager: LinksManager, linksUsed: boolean, linksChanged: boolean}>}
+ * Links metadata used by the page.
+ */
+export async function manageLinks(page, siteDir, path, pretty) {
+  const linksManager = new LinksManager(join(siteDir, "links.json"));
+  await linksManager.load();
+  const rel = relative(siteDir, path).replace(/\\/g, "/");
+  const href = toHref(rel, pretty);
+  const linksUsed = page.frontMatter.links !== undefined;
+  const linksChanged = linksManager.merge(href, page.links ?? {});
+  if (linksChanged) await linksManager.save();
+  return { linksManager, linksUsed, linksChanged };
+}
+
+/**
+ * Build the href used in `links.json` for a page.
+ *
+ * @param {string} rel Page path relative to the site root.
+ * @param {boolean} pretty Whether `.html` extensions should be omitted.
+ * @returns {string} Href beginning with a leading slash.
+ */
+export function toHref(rel, pretty) {
+  const normalized = rel.replace(/\\/g, "/").replace(/\.(md|html?)$/i, ".html");
+  if (!pretty) return "/" + normalized;
+  return "/" + normalized.replace(/index\.html$/i, "").replace(/\.html$/i, "/");
+}

--- a/lib/path-utils.test.js
+++ b/lib/path-utils.test.js
@@ -1,0 +1,14 @@
+import { toHref } from "./manage-links.js";
+import { toOutRel } from "./write-output.js";
+import { assertEquals } from "@std/assert";
+
+Deno.test("toHref respects pretty option", () => {
+  assertEquals(toHref("about.html", false), "/about.html");
+  assertEquals(toHref("blog/index.html", true), "/blog/");
+  assertEquals(toHref("blog/post.html", true), "/blog/post/");
+});
+
+Deno.test("toOutRel builds correct output paths", () => {
+  assertEquals(toOutRel("about.md", false), "about.html");
+  assertEquals(toOutRel("blog/post.md", true), "blog/post.html");
+});

--- a/lib/process-css.js
+++ b/lib/process-css.js
@@ -1,0 +1,56 @@
+import { dirname, join, fromFileUrl } from "@std/path";
+import { hashAssetName } from "./hash-asset.js";
+import { copyAsset } from "./copy-asset.js";
+import { getEmoji } from "./emoji.js";
+
+/**
+ * Handle CSS references from page front matter.
+ *
+ * @param {import('./parse-page.js').ParsedPage} page Parsed page object.
+ * @param {string} siteDir Site root directory.
+ * @param {boolean} hashAssets Whether asset hashing is enabled.
+ * @returns {Promise<string[]>} List of CSS files used by the page.
+ */
+export async function processCss(page, siteDir, hashAssets) {
+  const cssUsed = [];
+  const cssFiles = page.frontMatter.css ?? [];
+  page.frontMatter.css = await Promise.all(
+    cssFiles.map(async (href) => {
+      const relHref = href.startsWith("/") ? href.slice(1) : href;
+      const abs = join(siteDir, relHref);
+      try {
+        const real = await Deno.realPath(abs);
+        cssUsed.push(real);
+        if (!hashAssets) return href;
+        const hashed = await hashAssetName(real);
+        const dirRel = dirname(relHref);
+        const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+          .replace(/\\/g, "/");
+        return href.startsWith("/") ? "/" + relPath : relPath;
+      } catch {
+        const corePath = fromFileUrl(
+          new URL(`../core/css/${relHref}`, import.meta.url),
+        );
+        try {
+          await Deno.stat(corePath);
+          cssUsed.push(abs);
+          if (hashAssets) {
+            const hashed = await hashAssetName(corePath);
+            const dirRel = dirname(relHref);
+            const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+              .replace(/\\/g, "/");
+            await copyAsset(abs);
+            return href.startsWith("/") ? "/" + relPath : relPath;
+          }
+          await copyAsset(abs);
+          return href;
+        } catch {
+          console.log(`${getEmoji("error")} CSS missing -- ${relHref}`);
+          cssUsed.push(abs);
+          return href;
+        }
+      }
+    }),
+  );
+  return cssUsed;
+}

--- a/lib/process-modules.js
+++ b/lib/process-modules.js
@@ -1,0 +1,35 @@
+import { dirname, join } from "@std/path";
+import { hashAssetName } from "./hash-asset.js";
+
+/**
+ * Handle module script references defined in front matter.
+ *
+ * @param {import('./parse-page.js').ParsedPage} page Parsed page object.
+ * @param {string} siteDir Site root directory.
+ * @param {boolean} hashAssets Whether asset hashing is enabled.
+ * @returns {Promise<string[]>} List of module script files used by the page.
+ */
+export async function processModules(page, siteDir, hashAssets) {
+  const modulesUsed = [];
+  const moduleFiles = page.scripts.modules ?? [];
+  page.scripts.modules = await Promise.all(
+    moduleFiles.map(async (src) => {
+      const relSrc = src.startsWith("/") ? src.slice(1) : src;
+      const abs = join(siteDir, relSrc);
+      let real;
+      try {
+        real = await Deno.realPath(abs);
+      } catch {
+        real = abs;
+      }
+      modulesUsed.push(real);
+      if (!hashAssets) return src;
+      const hashed = await hashAssetName(abs);
+      const dirRel = dirname(relSrc);
+      const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+        .replace(/\\/g, "/");
+      return src.startsWith("/") ? "/" + relPath : relPath;
+    }),
+  );
+  return modulesUsed;
+}

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,13 +1,13 @@
-import { dirname, join, relative, toFileUrl, fromFileUrl } from "@std/path";
-import { hashAssetName } from "./hash-asset.js";
-import { copyAsset } from "./copy-asset.js";
-import { DOMParser } from "@b-fuze/deno-dom";
+import { join, relative } from "@std/path";
 import { parsePage } from "./parse-page.js";
-import { LinksManager } from "./links.js";
-import { applyTemplates } from "./apply-templates.js";
-import { inlineSvg } from "./inline-svg.js";
-import { getEmoji } from "./emoji.js";
 import { markdownToHTML } from "./markdown.js";
+import { getEmoji } from "./emoji.js";
+import { loadConfig, findSiteRoot } from "./load-config.js";
+import { processCss } from "./process-css.js";
+import { processModules } from "./process-modules.js";
+import { manageLinks } from "./manage-links.js";
+import { buildDocument } from "./build-document.js";
+import { writeOutput, toOutRel } from "./write-output.js";
 
 /**
  * @typedef {object} RenderResult
@@ -43,150 +43,31 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       }
     }
 
-    const siteDir = await findSiteRoot(path);
-    const configPath = join(siteDir, "config.json");
-    const configText = await Deno.readTextFile(configPath);
-    const config = JSON.parse(configText);
+    const { siteDir, config } = await loadConfig(path);
     const distant = String(config.distantDirectory);
     const pretty = Boolean(config.prettyUrls);
     const hashAssets = Boolean(config.hashAssets);
 
-    const cssUsed = [];
-    const cssFiles = page.frontMatter.css ?? [];
-    page.frontMatter.css = await Promise.all(
-      cssFiles.map(async (href) => {
-        const relHref = href.startsWith("/") ? href.slice(1) : href;
-        const abs = join(siteDir, relHref);
-        try {
-          const real = await Deno.realPath(abs);
-          cssUsed.push(real);
-          if (!hashAssets) return href;
-          const hashed = await hashAssetName(real);
-          const dirRel = dirname(relHref);
-          const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-            .replace(/\\/g, "/");
-          return href.startsWith("/") ? "/" + relPath : relPath;
-        } catch {
-          const corePath = fromFileUrl(
-            new URL(`../core/css/${relHref}`, import.meta.url),
-          );
-          try {
-            await Deno.stat(corePath);
-            cssUsed.push(abs);
-            if (hashAssets) {
-              const hashed = await hashAssetName(corePath);
-              const dirRel = dirname(relHref);
-              const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-                .replace(/\\/g, "/");
-              await copyAsset(abs);
-              return href.startsWith("/") ? "/" + relPath : relPath;
-            }
-            await copyAsset(abs);
-            return href;
-          } catch {
-            console.log(`${getEmoji("error")} CSS missing -- ${relHref}`);
-            cssUsed.push(abs);
-            return href;
-          }
-        }
-      }),
-    );
-    const modulesUsed = [];
-    const moduleFiles = page.scripts.modules ?? [];
-    page.scripts.modules = await Promise.all(
-      moduleFiles.map(async (src) => {
-        const relSrc = src.startsWith("/") ? src.slice(1) : src;
-        const abs = join(siteDir, relSrc);
-        let real;
-        try {
-          real = await Deno.realPath(abs);
-        } catch {
-          real = abs;
-        }
-        modulesUsed.push(real);
-        if (!hashAssets) return src;
-        const hashed = await hashAssetName(abs);
-        const dirRel = dirname(relSrc);
-        const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-          .replace(/\\/g, "/");
-        return src.startsWith("/") ? "/" + relPath : relPath;
-      }),
-    );
+    const cssUsed = await processCss(page, siteDir, hashAssets);
+    const modulesUsed = await processModules(page, siteDir, hashAssets);
 
-    const linksManager = new LinksManager(join(siteDir, "links.json"));
-    await linksManager.load();
-    const rel = relative(siteDir, path).replace(/\\/g, "/");
-    const href = toHref(rel, pretty);
-    const linksUsed = page.frontMatter.links !== undefined;
-    // Always merge so links are pruned when omitted from the page.
-    const linksChanged = linksManager.merge(href, page.links ?? {});
-    if (linksChanged) await linksManager.save();
-
-    const parser = new DOMParser();
-    // Build a minimal document. Templates are responsible for generating
-    // the final <head> and <body> structure.
-    const doc = parser.parseFromString("<html></html>", "text/html");
-    if (!doc) throw new Error(`${path}: invalid HTML`);
-
-    const templatesUsed = await applyTemplates(
-      doc,
+    const { linksManager, linksUsed, linksChanged } = await manageLinks(
       page,
-      linksManager.data,
+      siteDir,
+      path,
+      pretty,
+    );
+
+    const { doc, templatesUsed, scriptsUsed, svgsUsed } = await buildDocument(
+      page,
+      linksManager,
       config,
       root,
+      siteDir,
+      path,
     );
 
-    const body = doc.querySelector("body");
-    if (!body) throw new Error(`${path}: missing <body> element`);
-
-    for (const src of page.scripts.modules ?? []) {
-      const script = doc.createElement("script");
-      script.setAttribute("type", "module");
-      script.setAttribute("src", src);
-      body.appendChild(script);
-    }
-
-    const scriptsUsed = [];
-    for (const file of page.scripts.inline ?? []) {
-      const scriptPath = join(siteDir, file);
-      let realPath;
-      try {
-        realPath = await Deno.realPath(scriptPath);
-      } catch {
-        realPath = scriptPath;
-      }
-      let content;
-      try {
-        content = await Deno.readTextFile(realPath);
-      } catch (err) {
-        if (err instanceof Error) err.message = `${realPath}: ${err.message}`;
-        throw err;
-      }
-      scriptsUsed.push(realPath);
-      const script = doc.createElement("script");
-      script.textContent = content;
-      body.appendChild(script);
-    }
-
-    const svgsUsed = await inlineSvg(doc, toFileUrl(siteDir + "/"));
-
-    const outRel = toOutRel(rel, pretty);
-    const outPath = join(distant, outRel);
-    await Deno.mkdir(dirname(outPath), { recursive: true });
-    const htmlOut = "<!DOCTYPE html>\n" + doc.documentElement.outerHTML;
-    await Deno.writeTextFile(outPath, htmlOut);
-
-    const fmtCmd = new Deno.Command(Deno.execPath(), {
-      args: ["fmt", outPath],
-      stdout: "null",
-      stderr: "piped",
-    });
-    const { code, stderr } = await fmtCmd.output();
-    if (code !== 0) {
-      throw new Error(
-        `${outPath}: ${new TextDecoder().decode(stderr).trim()}`,
-      );
-    }
+    await writeOutput(doc, path, siteDir, distant, pretty);
 
     return {
       pagePath: path,
@@ -228,61 +109,5 @@ export async function removePage(path) {
     await Deno.remove(outPath);
   } catch (err) {
     if (!(err instanceof Deno.errors.NotFound)) throw err;
-  }
-}
-
-/**
- * Build the href used in `links.json` for a page.
- *
- * @param {string} rel Page path relative to the site root.
- * @param {boolean} pretty Whether `.html` extensions should be omitted.
- * @returns {string} Href beginning with a leading slash.
- */
-function toHref(rel, pretty) {
-  const normalized = rel.replace(/\\/g, "/").replace(/\.(md|html?)$/i, ".html");
-  if (!pretty) return "/" + normalized;
-  return "/" +
-    normalized.replace(/index\.html$/i, "").replace(/\.html$/i, "/");
-}
-
-/**
- * Determine output file path relative to the distant directory.
- *
- * @param {string} rel Page path relative to the site root.
- * @param {boolean} pretty When true, preserve the original file structure
- * without creating nested `index.html` directories.
- * @returns {string} Relative output path within the distant directory.
- */
-function toOutRel(rel, pretty) {
-  const normalized = rel.replace(/\\/g, "/");
-  if (pretty) {
-    // Ensure the file keeps a `.html` extension without nesting it under an
-    // additional directory. Previously this would transform `foo.html` into
-    // `foo/index.html` which broke references to the generated file.
-    return normalized.replace(/\.(md|html?)$/i, ".html");
-  }
-  return normalized.replace(/\.(md|html?)$/i, "") + ".html";
-}
-
-/**
- * Walk up the directory hierarchy to find the site root containing `config.json`.
- *
- * @param {string} filePath Starting path used to search for the site root.
- * @returns {Promise<string>} Directory path containing `config.json`.
- */
-async function findSiteRoot(filePath) {
-  let dir = dirname(filePath);
-  while (true) {
-    try {
-      const stat = await Deno.stat(join(dir, "config.json"));
-      if (stat.isFile) return dir;
-    } catch (err) {
-      if (!(err instanceof Deno.errors.NotFound)) throw err;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) {
-      throw new Error(`config.json not found for ${filePath}`);
-    }
-    dir = parent;
   }
 }

--- a/lib/write-output.js
+++ b/lib/write-output.js
@@ -1,0 +1,46 @@
+import { dirname, join, relative } from "@std/path";
+
+/**
+ * Write the rendered HTML document to its destination and format it.
+ *
+ * @param {import('@b-fuze/deno-dom').DOMDocument} doc DOM document to write.
+ * @param {string} path Absolute path to the source file.
+ * @param {string} siteDir Site root directory.
+ * @param {string} distant Output directory for generated files.
+ * @param {boolean} pretty Whether to use pretty URLs.
+ * @returns {Promise<void>} Resolves when the file has been written.
+ */
+export async function writeOutput(doc, path, siteDir, distant, pretty) {
+  const rel = relative(siteDir, path).replace(/\\/g, "/");
+  const outRel = toOutRel(rel, pretty);
+  const outPath = join(distant, outRel);
+  await Deno.mkdir(dirname(outPath), { recursive: true });
+  const htmlOut = "<!DOCTYPE html>\n" + doc.documentElement.outerHTML;
+  await Deno.writeTextFile(outPath, htmlOut);
+
+  const fmtCmd = new Deno.Command(Deno.execPath(), {
+    args: ["fmt", outPath],
+    stdout: "null",
+    stderr: "piped",
+  });
+  const { code, stderr } = await fmtCmd.output();
+  if (code !== 0) {
+    throw new Error(`${outPath}: ${new TextDecoder().decode(stderr).trim()}`);
+  }
+}
+
+/**
+ * Determine output file path relative to the distant directory.
+ *
+ * @param {string} rel Page path relative to the site root.
+ * @param {boolean} pretty When true, preserve the original file structure
+ * without creating nested `index.html` directories.
+ * @returns {string} Relative output path within the distant directory.
+ */
+export function toOutRel(rel, pretty) {
+  const normalized = rel.replace(/\\/g, "/");
+  if (pretty) {
+    return normalized.replace(/\.(md|html?)$/i, ".html");
+  }
+  return normalized.replace(/\.(md|html?)$/i, "") + ".html";
+}


### PR DESCRIPTION
## Summary
- merge render pipeline refactor and centralize site root lookup via `load-config`
- update asset copier to use shared `findSiteRoot`
- add tests for site root discovery through `load-config`

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68931b9c06c08331ae4e15ee21eea3ca