### PR TITLE
refactor: standardize emoji logging

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -47,10 +47,16 @@ export function getEmoji(action) {
 export function logWithEmoji(action, ...args) {
   const emoji = getEmoji(action);
   const message = args.join(" ");
-  if (emoji) {
-    console.log(`${emoji} ${message}`);
-  } else {
-    console.log(message);
+  const output = emoji ? `${emoji} ${message}` : message;
+  switch (action) {
+    case "error":
+      console.error(output);
+      break;
+    case "warning":
+      console.warn(output);
+      break;
+    default:
+      console.log(output);
   }
 }
 

--- a/lib/emoji.test.js
+++ b/lib/emoji.test.js
@@ -11,15 +11,28 @@ Deno.test("getEmoji returns correct emoji", () => {
   assertEquals(getEmoji("unknown"), "");
 });
 
-Deno.test("logWithEmoji prefixes message with emoji", () => {
-  const logs = [];
-  const orig = console.log;
-  console.log = (msg) => logs.push(msg);
+Deno.test("logWithEmoji logs errors with emoji", () => {
+  const errors = [];
+  const orig = console.error;
+  console.error = (msg) => errors.push(msg);
   try {
     logWithEmoji("error", "Something failed");
   } finally {
-    console.log = orig;
+    console.error = orig;
   }
-  assertEquals(logs.length, 1);
-  assertEquals(logs[0], "❌ Something failed");
+  assertEquals(errors.length, 1);
+  assertEquals(errors[0], "❌ Something failed");
+});
+
+Deno.test("logWithEmoji logs warnings with emoji", () => {
+  const warnings = [];
+  const orig = console.warn;
+  console.warn = (msg) => warnings.push(msg);
+  try {
+    logWithEmoji("warning", "Be careful");
+  } finally {
+    console.warn = orig;
+  }
+  assertEquals(warnings.length, 1);
+  assertEquals(warnings[0], "⚠️ Be careful");
 });

--- a/lib/inline-svg.js
+++ b/lib/inline-svg.js
@@ -1,5 +1,5 @@
 import { fromFileUrl } from "@std/path";
-import { getEmoji } from "./emoji.js";
+import { logWithEmoji } from "./emoji.js";
 
 /**
  * Replace `<icon>` and `<logo>` elements with inline SVG content.
@@ -21,8 +21,9 @@ export async function inlineSvg(doc, root = new URL("..", import.meta.url)) {
       svg = await Deno.readTextFile(fileUrl);
     } catch (err) {
       if (err instanceof Deno.errors.NotFound) {
-        console.error(
-          `${getEmoji("error")} Missing SVG: ${fileUrl.pathname}`,
+        logWithEmoji(
+          "error",
+          `Missing SVG: ${fileUrl.pathname}`,
         );
         continue;
       }

--- a/lib/parse-page.js
+++ b/lib/parse-page.js
@@ -1,5 +1,5 @@
 import { parse as parseToml } from "@std/toml";
-import { getEmoji } from "./emoji.js";
+import { logWithEmoji } from "./emoji.js";
 
 const TOP_LEVEL_KEYS = [
   "title",
@@ -74,8 +74,9 @@ export async function parsePage(path) {
 function validateFrontMatter(fm, path) {
   for (const key of Object.keys(fm)) {
     if (!TOP_LEVEL_KEYS.includes(key)) {
-      console.warn(
-        `${getEmoji("warning")} ${path}: unknown front-matter key \"${key}\"`,
+      logWithEmoji(
+        "warning",
+        `${path}: unknown front-matter key \"${key}\"`,
       );
     }
   }
@@ -98,8 +99,9 @@ function validateFrontMatter(fm, path) {
   }
   for (const key of Object.keys(templates)) {
     if (!TEMPLATE_KEYS.includes(key)) {
-      console.warn(
-        `${getEmoji("warning")} ${path}: unknown \"templates.${key}\" key`,
+      logWithEmoji(
+        "warning",
+        `${path}: unknown \"templates.${key}\" key`,
       );
     }
   }
@@ -122,8 +124,9 @@ function validateFrontMatter(fm, path) {
     }
     for (const key of Object.keys(scripts)) {
       if (!SCRIPT_KEYS.includes(key)) {
-        console.warn(
-          `${getEmoji("warning")} ${path}: unknown \"scripts.${key}\" key`,
+        logWithEmoji(
+          "warning",
+          `${path}: unknown \"scripts.${key}\" key`,
         );
       }
     }
@@ -163,8 +166,9 @@ function validateFrontMatter(fm, path) {
     }
     for (const key of Object.keys(links)) {
       if (!LINK_SECTIONS.includes(key)) {
-        console.warn(
-          `${getEmoji("warning")} ${path}: unknown \"links.${key}\" key`,
+        logWithEmoji(
+          "warning",
+          `${path}: unknown \"links.${key}\" key`,
         );
       }
     }
@@ -176,8 +180,9 @@ function validateFrontMatter(fm, path) {
       }
       for (const key of Object.keys(nav)) {
         if (!NAV_LINK_KEYS.includes(key)) {
-          console.warn(
-            `${getEmoji("warning")} ${path}: unknown \"links.nav.${key}\" key`,
+          logWithEmoji(
+            "warning",
+            `${path}: unknown \"links.nav.${key}\" key`,
           );
         }
       }
@@ -199,11 +204,10 @@ function validateFrontMatter(fm, path) {
       }
       for (const key of Object.keys(footer)) {
         if (!FOOTER_LINK_KEYS.includes(key)) {
-          console.warn(
-            `${
-              getEmoji("warning")
-            } ${path}: unknown \"links.footer.${key}\" key`,
-          );
+        logWithEmoji(
+          "warning",
+          `${path}: unknown \"links.footer.${key}\" key`,
+        );
         }
       }
       if (footer.column !== undefined && typeof footer.column !== "string") {

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,7 +1,7 @@
 import { join, relative } from "@std/path";
 import { parsePage } from "./parse-page.js";
 import { markdownToHTML } from "./markdown.js";
-import { getEmoji } from "./emoji.js";
+import { logWithEmoji } from "./emoji.js";
 import { loadConfig, findSiteRoot } from "./load-config.js";
 import { processCss } from "./process-css.js";
 import { processModules } from "./process-modules.js";
@@ -86,7 +86,7 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
         err.message = `${path}: ${err.message}`;
       }
     }
-    console.error(getEmoji("error"), err);
+    logWithEmoji("error", err);
   }
 }
 

--- a/lib/worker-pool.js
+++ b/lib/worker-pool.js
@@ -1,3 +1,5 @@
+import { logWithEmoji } from "./emoji.js";
+
 /**
  * Represents a task queued for a worker.
  * @typedef {{ id?: number, [key: string]: unknown }} WorkerTask
@@ -39,7 +41,7 @@ export class WorkerPool {
       try {
         cb(e);
       } catch (err) {
-        console.warn(`WorkerPool callback threw error: ${err.message}`);
+        logWithEmoji("warning", `WorkerPool callback threw error: ${err.message}`);
       }
     }
 
@@ -62,7 +64,7 @@ export class WorkerPool {
    * @param {ErrorEvent} e - Error event emitted by the worker.
    */
   _handleError(worker, e) {
-    console.error(`Worker error: ${e.message}`);
+    logWithEmoji("error", `Worker error: ${e.message}`);
     // Optionally implement retry or worker replacement
   }
 

--- a/scripts/ensure-distant-dirs.js
+++ b/scripts/ensure-distant-dirs.js
@@ -6,7 +6,7 @@ import {
   normalize,
   resolve,
 } from "@std/path";
-import { getEmoji, logWithEmoji } from "../lib/emoji.js";
+import { logWithEmoji } from "../lib/emoji.js";
 
 /**
  * Walks each immediate subdirectory of `src/`, validates its `config.json`
@@ -27,7 +27,7 @@ async function main() {
     }
   } catch (err) {
     if (err instanceof Deno.errors.NotFound) {
-      console.warn(`${getEmoji("warning")} No src directory found.`);
+      logWithEmoji("warning", "No src directory found.");
       return;
     }
     throw err;
@@ -50,8 +50,9 @@ async function main() {
       config = JSON.parse(text);
       logWithEmoji("success", `CONFIG -- ${dirent.name} `);
     } catch (_err) {
-      console.warn(
-        `${getEmoji("error")} Skipping ${dirent.name}: cannot read config.json`,
+      logWithEmoji(
+        "warning",
+        `Skipping ${dirent.name}: cannot read config.json`,
       );
       continue;
     }
@@ -111,7 +112,7 @@ function validateConfig(config, schema) {
 
 if (import.meta.main) {
   main().catch((err) => {
-    console.error(getEmoji("error"), err);
+    logWithEmoji("error", err);
     Deno.exit(1);
   });
 }


### PR DESCRIPTION
## Summary
- route warnings and errors through `logWithEmoji`
- update modules to use `logWithEmoji` for consistent emoji logs

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_689326f5ee9c8331a46764c405728c21