### PR TITLE
refactor: modularize watch handlers

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -8,10 +8,6 @@ import {
   pagesWithLinks,
   recordPageDeps,
 } from "./page-deps.js";
-import {
-  MEDIA_EXTENSIONS,
-  SRC_ASSET_EXTENSIONS,
-} from "./extension-whitelist.js";
 import { getEmoji } from "./emoji.js";
 import { classifyPath, reduceEvents } from "./fs-utils.js";
 import { WorkerPool } from "./worker-pool.js";
@@ -46,6 +42,168 @@ function workerRenderPage(path) {
     ],
   ];
 }
+
+/**
+ * Schedule rendering of a page when its HTML changes.
+ *
+ * @param {string} path - Path to the page file.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handlePageHtml(path, tasks) {
+  tasks.set(path, workerRenderPage(path));
+}
+
+/**
+ * Handle updates to a template file by re-rendering dependent pages.
+ *
+ * @param {string} path - Path to the template.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handleTemplateUpdate(path, tasks) {
+  console.log(`${getEmoji("update")} TEMPLATE UPDATED -- ${path}`);
+  for (const page of pagesUsingTemplate(path)) {
+    tasks.set(page, workerRenderPage(page));
+  }
+}
+
+/**
+ * Handle updates to an inline script by refreshing referencing pages.
+ *
+ * @param {string} path - Path to the inline script.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handleInlineScriptUpdate(path, tasks) {
+  console.log(`${getEmoji("update")} INLINE SCRIPT UPDATED -- ${path}`);
+  const pages = pagesUsingScript(path);
+  if (pages.length === 0) {
+    console.log(`  ${getEmoji("warning")} no pages reference this inline script`);
+    return;
+  }
+  for (const page of pages) {
+    tasks.set(page, workerRenderPage(page));
+  }
+  console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
+}
+
+/**
+ * Handle updates to an inline SVG by re-rendering dependent pages.
+ *
+ * @param {string} path - Path to the SVG file.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handleInlineSvgUpdate(path, tasks) {
+  console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
+  const pages = pagesUsingSvg(path);
+  if (pages.length === 0) {
+    console.log(`  ${getEmoji("warning")} no pages reference this SVG`);
+    return;
+  }
+  for (const page of pages) {
+    tasks.set(page, workerRenderPage(page));
+  }
+  console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
+}
+
+/**
+ * Handle a CSS asset change by updating pages that reference it.
+ *
+ * @param {string} path - Path to the CSS asset.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handleCssAsset(path, tasks) {
+  console.log(`${getEmoji("update")} CSS UPDATED -- ${path}`);
+  const pages = pagesUsingCss(path);
+  if (pages.length === 0) {
+    console.log(`  ${getEmoji("warning")} no pages reference this stylesheet`);
+    return;
+  }
+  for (const page of pages) {
+    tasks.set(page, workerRenderPage(page));
+  }
+  console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
+}
+
+/**
+ * Handle a JavaScript module change by updating referencing pages.
+ *
+ * @param {string} path - Path to the module file.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handleModuleAsset(path, tasks) {
+  console.log(`${getEmoji("update")} MODULE UPDATED -- ${path}`);
+  const pages = pagesUsingModule(path);
+  if (pages.length === 0) {
+    console.log(`  ${getEmoji("warning")} no pages reference this module`);
+    return;
+  }
+  for (const page of pages) {
+    tasks.set(page, workerRenderPage(page));
+  }
+  console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
+}
+
+/**
+ * Handle updates to generic assets and delegate to specific handlers.
+ *
+ * @param {string} path - Path to the asset.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handleAssetUpdate(path, tasks) {
+  workerPool.push(`asset:${path}`, { type: "asset", path });
+  const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+  if (ext === ".css") {
+    handleCssAsset(path, tasks);
+  } else if (ext === ".js" && !path.endsWith(".inline.js")) {
+    handleModuleAsset(path, tasks);
+  }
+}
+
+/**
+ * Remove a page output when its source HTML is deleted.
+ *
+ * @param {string} path - Path to the page file.
+ */
+function handlePageRemove(path) {
+  workerPool.push(`remove:${path}`, { type: "remove-page", path });
+}
+
+/**
+ * Remove an asset output when deleted.
+ *
+ * @param {string} path - Path to the asset file.
+ */
+function handleAssetRemove(path) {
+  workerPool.push(`remove:${path}`, { type: "remove-asset", path });
+}
+
+/**
+ * Handle removal of a template by re-rendering dependent pages.
+ *
+ * @param {string} path - Path to the removed template.
+ * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
+ */
+function handleTemplateRemove(path, tasks) {
+  console.log(`${getEmoji("delete")} TEMPLATE REMOVED -- ${path}`);
+  for (const page of pagesUsingTemplate(path)) {
+    tasks.set(page, workerRenderPage(page));
+  }
+}
+
+/** @type {Record<string, (p: string, t: Map<string, ReturnType<typeof workerRenderPage>>) => void>} */
+const createModifyHandlers = {
+  PAGE_HTML: handlePageHtml,
+  TEMPLATE: handleTemplateUpdate,
+  JS_INLINE: handleInlineScriptUpdate,
+  SVG_INLINE: handleInlineSvgUpdate,
+  ASSET: handleAssetUpdate,
+};
+
+/** @type {Record<string, (p: string, t: Map<string, ReturnType<typeof workerRenderPage>>) => void>} */
+const removeHandlers = {
+  PAGE_HTML: (p) => handlePageRemove(p),
+  ASSET: (p) => handleAssetRemove(p),
+  TEMPLATE: handleTemplateRemove,
+};
 
 /**
  * Watch the source and template directories for changes and trigger rebuilds.
@@ -99,87 +257,11 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
     for (const [path, evtKind] of paths) {
       const kind = classifyPath(path);
       if (evtKind === "create" || evtKind === "modify") {
-        if (kind === "PAGE_HTML") {
-          tasks.set(path, workerRenderPage(path));
-        } else if (kind === "TEMPLATE") {
-          console.log(`${getEmoji("update")} TEMPLATE UPDATED -- ${path}`);
-          for (const page of pagesUsingTemplate(path)) {
-            tasks.set(page, workerRenderPage(page));
-          }
-        } else if (kind === "JS_INLINE") {
-          console.log(`${getEmoji("update")} INLINE SCRIPT UPDATED -- ${path}`);
-          const pages = pagesUsingScript(path);
-          if (pages.length === 0) {
-            console.log(
-              `  ${getEmoji("warning")} no pages reference this inline script`,
-            );
-          } else {
-            for (const page of pages) {
-              tasks.set(page, workerRenderPage(page));
-            }
-            console.log(
-              `  ${getEmoji("update")} ${pages.length} page(s) updated`,
-            );
-          }
-        } else if (kind === "SVG_INLINE") {
-          console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
-          const pages = pagesUsingSvg(path);
-          if (pages.length === 0) {
-            console.log(`  ${getEmoji("warning")} no pages reference this SVG`);
-          } else {
-            for (const page of pages) {
-              tasks.set(page, workerRenderPage(page));
-            }
-            console.log(
-              `  ${getEmoji("update")} ${pages.length} page(s) updated`,
-            );
-          }
-        } else if (kind === "ASSET") {
-          workerPool.push(`asset:${path}`, { type: "asset", path });
-          const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
-          if (ext === ".css") {
-            console.log(`${getEmoji("update")} CSS UPDATED -- ${path}`);
-            const pages = pagesUsingCss(path);
-            if (pages.length === 0) {
-              console.log(
-                `  ${getEmoji("warning")} no pages reference this stylesheet`,
-              );
-            } else {
-              for (const page of pages) {
-                tasks.set(page, workerRenderPage(page));
-              }
-              console.log(
-                `  ${getEmoji("update")} ${pages.length} page(s) updated`,
-              );
-            }
-          } else if (ext === ".js" && !path.endsWith(".inline.js")) {
-            console.log(`${getEmoji("update")} MODULE UPDATED -- ${path}`);
-            const pages = pagesUsingModule(path);
-            if (pages.length === 0) {
-              console.log(
-                `  ${getEmoji("warning")} no pages reference this module`,
-              );
-            } else {
-              for (const page of pages) {
-                tasks.set(page, workerRenderPage(page));
-              }
-              console.log(
-                `  ${getEmoji("update")} ${pages.length} page(s) updated`,
-              );
-            }
-          }
-        }
+        const handler = createModifyHandlers[kind];
+        if (handler) handler(path, tasks);
       } else if (evtKind === "remove") {
-        if (kind === "PAGE_HTML") {
-          workerPool.push(`remove:${path}`, { type: "remove-page", path });
-        } else if (kind === "ASSET") {
-          workerPool.push(`remove:${path}`, { type: "remove-asset", path });
-        } else if (kind === "TEMPLATE") {
-          console.log(`${getEmoji("delete")} TEMPLATE REMOVED -- ${path}`);
-          for (const page of pagesUsingTemplate(path)) {
-            tasks.set(page, workerRenderPage(page));
-          }
-        }
+        const handler = removeHandlers[kind];
+        if (handler) handler(path, tasks);
       }
     }
     await Promise.all(


### PR DESCRIPTION
## Summary
- factor watch file classifications into dedicated handler functions
- simplify flush logic with handler dispatch table

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_689328dccd58833198311fe94ab5ac6d