### PR TITLE
fix: align watch workerPool calls with current API

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -149,7 +149,7 @@ function handleModuleAsset(path, tasks) {
  * @param {Map<string, ReturnType<typeof workerRenderPage>>} tasks - Map of queued tasks.
  */
 function handleAssetUpdate(path, tasks) {
-  workerPool.push(`asset:${path}`, { type: "asset", path });
+  workerPool.push({ type: "asset", path });
   const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
   if (ext === ".css") {
     handleCssAsset(path, tasks);
@@ -164,7 +164,7 @@ function handleAssetUpdate(path, tasks) {
  * @param {string} path - Path to the page file.
  */
 function handlePageRemove(path) {
-  workerPool.push(`remove:${path}`, { type: "remove-page", path });
+  workerPool.push({ type: "remove-page", path });
 }
 
 /**
@@ -173,7 +173,7 @@ function handlePageRemove(path) {
  * @param {string} path - Path to the asset file.
  */
 function handleAssetRemove(path) {
-  workerPool.push(`remove:${path}`, { type: "remove-asset", path });
+  workerPool.push({ type: "remove-asset", path });
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove obsolete key argument when scheduling asset and removal tasks
- prevent crashes when renaming or removing files during watch

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68a99e57988c8331a4e92797dc8f5780