### PR TITLE
feat: add converter registry and plugins

### DIFF
--- a/core/templates/blog/default.js
+++ b/core/templates/blog/default.js
@@ -1,42 +1,40 @@
-import { markdownToHTML } from "../../../lib/markdown";
+import { markdownToHTML } from "../../../plugins/markdown.js";
 
-function generateHTMLContent(target = "/") {
-    let entries = [];
-    for await (const entry of Deno.readDir(target)) {
-        entries.push(markdownToHTML(entry));
-      }
-    return entries;
+/**
+ * Read Markdown files from a directory and convert them to HTML strings.
+ *
+ * @param {string} [target="/"] Directory to scan for Markdown files.
+ * @returns {Promise<string[]>} Converted HTML snippets.
+ */
+export async function generateHTMLContent(target = "/") {
+  const entries = [];
+  for await (const entry of Deno.readDir(target)) {
+    entries.push(markdownToHTML(entry.name));
+  }
+  return entries;
 }
 
-
-// Markdown to HTML (pseudo-code, using a markdown parser)
-const html = gfm.render(markdownContent); // or mm-mark or similar
-
-// DOMParser to manipulate the HTML string
-const parser = new DOMParser();
-const doc = parser.parseFromString(html, 'text/html');
-
-// Collect all h2 headings (section titles)
-const sectionTitles = [...doc.querySelectorAll('h2')];
-
-// Build navigation
-const nav = document.createElement('nav');
-nav.className = 'toc-fixed'; // Add styles for fixed positioning
-
-const ul = document.createElement('ul');
-sectionTitles.forEach(h2 => {
-  // Generate a slug for the id
-  const slug = h2.textContent.toLowerCase().replace(/\s+/g, '-');
-  h2.id = slug; // Set the id in the heading
-
-  const li = document.createElement('li');
-  const a = document.createElement('a');
-  a.href = `#${slug}`;
-  a.textContent = h2.textContent;
-  li.appendChild(a);
-  ul.appendChild(li);
-});
-nav.appendChild(ul);
-
-// Render nav at desired position
-document.body.prepend(nav);
+/*
+ * Example DOM manipulation for generating a table of contents.
+ * This is placeholder code and not executed by default.
+ *
+ * const html = gfm.render(markdownContent);
+ * const parser = new DOMParser();
+ * const doc = parser.parseFromString(html, 'text/html');
+ * const sectionTitles = [...doc.querySelectorAll('h2')];
+ * const nav = document.createElement('nav');
+ * nav.className = 'toc-fixed';
+ * const ul = document.createElement('ul');
+ * sectionTitles.forEach((h2) => {
+ *   const slug = h2.textContent.toLowerCase().replace(/\s+/g, '-');
+ *   h2.id = slug;
+ *   const li = document.createElement('li');
+ *   const a = document.createElement('a');
+ *   a.href = `#${slug}`;
+ *   a.textContent = h2.textContent;
+ *   li.appendChild(a);
+ *   ul.appendChild(li);
+ * });
+ * nav.appendChild(ul);
+ * document.body.prepend(nav);
+ */

--- a/docs/06-rendering-pipeline.md
+++ b/docs/06-rendering-pipeline.md
@@ -52,7 +52,16 @@ flowchart TD
   [https://deno.land/x/deno\_dom](https://deno.land/x/deno_dom)’s `DOMParser`
   for subsequent manipulations.
 
-### 2.2 Update `links.json`
+### 2.2 Run file converters
+
+- Use `registerConverter(ext, fn)` to associate a function with a file
+  extension.
+- `convert(path, content)` looks up the converter based on the source file's
+  extension and returns the transformed HTML.
+- Built-in plugins handle Markdown (`.md`) and provide a sample JSON (`.json`)
+  conversion.
+
+### 2.3 Update `links.json`
 
 - If the page’s front‑matter contains **any** `links.*` keys, merge them into
   the site’s `links.json`.
@@ -66,7 +75,7 @@ flowchart TD
 - `links.json` is **auto‑managed**; manual edits are ignored and will be
   overwritten on the next page render.
 
-### 2.3 Apply templates
+### 2.4 Apply templates
 
 - Resolve file path: `templates/<slot>/<name>.js`.
 - Import (cached by Deno) and call `render({ frontMatter, links })`.
@@ -74,7 +83,7 @@ flowchart TD
 - For _nav_ / _footer_: returned fragment is inserted **before** the content and
   **after** it respectively.
 
-### 2.4 Inject styles & scripts
+### 2.5 Inject styles & scripts
 
 1. **CSS list** – Each entry becomes `<link rel="stylesheet" href="…">` inside
    `<head>`.
@@ -85,17 +94,17 @@ flowchart TD
 
    <!-- TODO: flag to allow `defer` scripts in head? -->
 
-### 2.5 Assemble & inline SVGs
+### 2.6 Assemble & inline SVGs
 
 - Combine head, nav, page content, footer, scripts into a DOM tree.
 - Replace each `<icon>` / `<logo>` node with SVG markup pulled from `src-svg/`.
 - Remove unused whitespace if `--minify` flag is passed.
   <!-- TODO: implement minify option -->
 
-### 2.6 Write output
+### 2.7 Write output
 
-- Compute destination: `<distantDirectory>/<relative/path/of/page>.html`
-  (Markdown sources are converted to `.html`).
+  - Compute destination: `<distantDirectory>/<relative/path/of/page>.html`
+    (all converted sources output as `.html`).
 - Ensure folders exist (`Deno.mkdir({ recursive: true })`).
 - Write file with UTF‑8 encoding.
 

--- a/lib/conversion-registry.js
+++ b/lib/conversion-registry.js
@@ -1,0 +1,41 @@
+/**
+ * Registry for file content converters based on extension.
+ *
+ * @typedef {(content: string, path: string) => string|Promise<string>} Converter
+ */
+
+/** @type {Map<string, Converter>} */
+const converters = new Map();
+
+/**
+ * Register a converter for a specific file extension.
+ * Passing a non-function removes the converter.
+ *
+ * @param {string} ext File extension beginning with a dot (e.g. ".md").
+ * @param {Converter} [fn] Converter invoked for matching files.
+ * @returns {void}
+ */
+export function registerConverter(ext, fn) {
+  const key = ext.toLowerCase();
+  if (typeof fn !== "function") {
+    converters.delete(key);
+    return;
+  }
+  converters.set(key, fn);
+}
+
+/**
+ * Convert source content based on the file path's extension.
+ *
+ * @param {string} path Absolute or relative path to the source file.
+ * @param {string} content Original file content.
+ * @returns {Promise<string>} Converted content if a converter exists.
+ */
+export async function convert(path, content) {
+  const idx = path.lastIndexOf(".");
+  const ext = idx !== -1 ? path.slice(idx).toLowerCase() : "";
+  const fn = converters.get(ext);
+  if (!fn) return content;
+  return await fn(content, path);
+}
+

--- a/lib/conversion-registry.test.js
+++ b/lib/conversion-registry.test.js
@@ -1,0 +1,15 @@
+import { convert, registerConverter } from "./conversion-registry.js";
+import { assertEquals } from "@std/assert";
+
+Deno.test("convert returns input when no converter registered", async () => {
+  const input = "<p>hi</p>";
+  const output = await convert("note.txt", input);
+  assertEquals(output, input);
+});
+
+Deno.test("registerConverter applies transformation", async () => {
+  registerConverter(".foo", (c) => c.toUpperCase());
+  const output = await convert("test.foo", "bar");
+  assertEquals(output, "BAR");
+  registerConverter(".foo");
+});

--- a/lib/path-utils.test.js
+++ b/lib/path-utils.test.js
@@ -11,4 +11,5 @@ Deno.test("toHref respects pretty option", () => {
 Deno.test("toOutRel builds correct output paths", () => {
   assertEquals(toOutRel("about.md", false), "about.html");
   assertEquals(toOutRel("blog/post.md", true), "blog/post.html");
+  assertEquals(toOutRel("data.json", false), "data.html");
 });

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,6 +1,5 @@
 import { join, relative, basename, dirname } from "@std/path";
 import { parsePage } from "./parse-page.js";
-import { markdownToHTML } from "./markdown.js";
 import { logWithEmoji } from "./emoji.js";
 import { findSiteRoot, loadConfig } from "./load-config.js";
 import { processCss } from "./process-css.js";
@@ -9,6 +8,11 @@ import { manageLinks } from "./manage-links.js";
 import { buildDocument } from "./build-document.js";
 import { toOutRel, writeOutput } from "./write-output.js";
 import { applyFrontMatterHandlers } from "./front-matter-handlers.js";
+import { convert } from "./conversion-registry.js";
+
+// Register built-in converters
+import "../plugins/markdown.js";
+import "../plugins/json.js";
 
 /** @type {Array<(page: any, context: any) => Promise<void>|void>} */
 const preProcessors = [];
@@ -42,13 +46,11 @@ export function registerPostProcessor(fn) {
  */
 export async function preProcess(page, context) {
   const { path } = context;
-  if (path.toLowerCase().endsWith(".md")) {
-    try {
-      page.html = markdownToHTML(page.html);
-    } catch (err) {
-      if (err instanceof Error) err.message = `${path}: ${err.message}`;
-      throw err;
-    }
+  try {
+    page.html = await convert(path, page.html);
+  } catch (err) {
+    if (err instanceof Error) err.message = `${path}: ${err.message}`;
+    throw err;
   }
 
   const { siteDir, config } = await loadConfig(path);

--- a/lib/write-output.js
+++ b/lib/write-output.js
@@ -40,9 +40,9 @@ export async function writeOutput(doc, path, siteDir, distant, pretty) {
 export function toOutRel(rel, pretty) {
   const normalized = rel.replace(/\\/g, "/");
   if (pretty) {
-    const final = normalized.replace(/\.(md|html?)$/i, ".html");
+    const final = normalized.replace(/\.[^.]+$/i, ".html");
     return final;
   }
-  const final = normalized.replace(/\.(md|html?)$/i, "") + ".html";
+  const final = normalized.replace(/\.[^.]+$/i, "") + ".html";
   return final;
 }

--- a/plugins/json.js
+++ b/plugins/json.js
@@ -1,0 +1,31 @@
+import { registerConverter } from "../lib/conversion-registry.js";
+
+/**
+ * Escape HTML special characters in a string.
+ *
+ * @param {string} text Input text to escape.
+ * @returns {string} Escaped text safe for HTML.
+ */
+function escapeHtml(text) {
+  return text.replace(/[&<>]/g, (ch) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+  })[ch]);
+}
+
+/**
+ * Convert a JSON string into a formatted HTML block.
+ *
+ * @param {string} [json=""] JSON source to convert.
+ * @returns {string} Generated HTML output.
+ */
+function jsonToHTML(json = "") {
+  const data = JSON.parse(json || "null");
+  const pretty = JSON.stringify(data, null, 2);
+  return `<pre>${escapeHtml(pretty)}</pre>`;
+}
+
+registerConverter(".json", jsonToHTML);
+
+export { jsonToHTML };

--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -1,4 +1,5 @@
 import { marked } from "npm:marked@16";
+import { registerConverter } from "../lib/conversion-registry.js";
 
 /**
  * Convert Markdown formatted text into HTML using the `marked` library.
@@ -6,9 +7,13 @@ import { marked } from "npm:marked@16";
  * @param {string} [markdown=""] Markdown source to convert.
  * @returns {string} Generated HTML output.
  */
-export function markdownToHTML(markdown = "") {
+function markdownToHTML(markdown = "") {
   return marked.parse(markdown, {
     headerIds: false,
     mangle: false,
   });
 }
+
+registerConverter(".md", markdownToHTML);
+
+export { markdownToHTML };

--- a/plugins/markdown.test.js
+++ b/plugins/markdown.test.js
@@ -1,23 +1,27 @@
-import { markdownToHTML } from "./markdown.js";
+import { convert } from "../lib/conversion-registry.js";
+import "./markdown.js";
 import { assertEquals } from "@std/assert";
 
-Deno.test("markdownToHTML converts basic elements", () => {
+Deno.test("markdown converter transforms basic elements", async () => {
   const input = "# Heading\n\nThis is **bold** and *italic* text.";
   const expected =
     "<h1>Heading</h1>\n<p>This is <strong>bold</strong> and <em>italic</em> text.</p>\n";
-  assertEquals(markdownToHTML(input), expected);
+  const result = await convert("test.md", input);
+  assertEquals(result, expected);
 });
 
-Deno.test("markdownToHTML handles code blocks and escaping", () => {
+Deno.test("markdown converter handles code blocks and escaping", async () => {
   const input = '```js\nconsole.log("<&>");\n```\n';
   const expected =
     '<pre><code class="language-js">console.log(&quot;&lt;&amp;&gt;&quot;);\n</code></pre>\n';
-  assertEquals(markdownToHTML(input), expected);
+  const result = await convert("code.md", input);
+  assertEquals(result, expected);
 });
 
-Deno.test("markdownToHTML processes tables", () => {
+Deno.test("markdown converter processes tables", async () => {
   const input = "| a | b |\n| --- | ---: |\n| 1 | 2 |\n";
   const expected =
     '<table>\n<thead>\n<tr>\n<th>a</th>\n<th align="right">b</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>1</td>\n<td align="right">2</td>\n</tr>\n</tbody></table>\n';
-  assertEquals(markdownToHTML(input), expected);
+  const result = await convert("table.md", input);
+  assertEquals(result, expected);
 });


### PR DESCRIPTION
## Summary
- add extensible conversion registry with `registerConverter` and `convert`
- move Markdown handling into plugin and add sample JSON→HTML plugin
- render pages through converter API and support generic output paths

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_68a9c7feedc48331b7267dfc3af3471b