### PR TITLE
fix: update markdown path and adjust tests

### DIFF
--- a/core/templates/blog/test.js
+++ b/core/templates/blog/test.js
@@ -1,9 +1,18 @@
 //import { render } from "./default.js";
-import { markdownToHTML } from "../../../lib/markdown.js";
+/**
+ * Example script that converts a markdown file to HTML and renders it using
+ * the blog template.
+ */
+import { markdownToHTML } from "../../../plugins/markdown.js";
 import { render } from "./default.js";
 
-const file = Deno.readTextFileSync("./testfolder/comment-retrouver-une-vie-epanouie.md");
+const markdownUrl = new URL(
+  "./testfolder/comment-retrouver-une-vie-epanouie.md",
+  import.meta.url,
+);
+const file = Deno.readTextFileSync(markdownUrl);
 const html = markdownToHTML(file);
 
-const output = render({html});
-console.log(output);
+const output = render({ html });
+// Log the rendered HTML for debugging with a friendly emoji
+console.log("📝", output);

--- a/lib/path-utils.test.js
+++ b/lib/path-utils.test.js
@@ -1,11 +1,15 @@
+/**
+ * Tests for path utility helpers ensuring URL and output paths are generated
+ * correctly.
+ */
 import { toHref } from "./manage-links.js";
 import { toOutRel } from "./write-output.js";
 import { assertEquals } from "@std/assert";
 
 Deno.test("toHref respects pretty option", () => {
   assertEquals(toHref("about.html", false), "/about.html");
-  assertEquals(toHref("blog/index.html", true), "/blog/");
-  assertEquals(toHref("blog/post.html", true), "/blog/post/");
+  assertEquals(toHref("blog/index.html", true), "/blog");
+  assertEquals(toHref("blog/post.html", true), "/blog/post");
 });
 
 Deno.test("toOutRel builds correct output paths", () => {

--- a/tests/pretty-urls.test.js
+++ b/tests/pretty-urls.test.js
@@ -1,3 +1,7 @@
+/**
+ * Integration test verifying that pages rendered with the `prettyUrls` option
+ * omit the `.html` extension without trailing slashes.
+ */
 import { renderPage } from "../lib/render-page.js";
 import { join, toFileUrl } from "@std/path";
 
@@ -60,5 +64,5 @@ Deno.test("renderPage supports prettyUrls", async () => {
     await Deno.readTextFile(join(siteDir, "links.json")),
   );
   assertEquals(links.nav[0], { href: "/", label: "Home", topLevel: true });
-  assertEquals(links.nav[1], { href: "/about/", label: "About" });
+  assertEquals(links.nav[1], { href: "/about", label: "About" });
 });


### PR DESCRIPTION
## Summary
- point blog template test to moved markdown plugin and use file URL for sample markdown
- align path utility and pretty URL tests with no-trailing-slash behavior

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68a9ee495d188331aa179283bf86a351