### PR TITLE
feat: apply blog template to blog pages

### DIFF
--- a/lib/build-document.js
+++ b/lib/build-document.js
@@ -1,7 +1,7 @@
 import { DOMParser } from "@b-fuze/deno-dom";
-import { applyTemplates } from "./apply-templates.js";
+import { applyTemplates, importTemplate } from "./apply-templates.js";
 import { inlineSvg } from "./inline-svg.js";
-import { join, toFileUrl } from "@std/path";
+import { join, relative, toFileUrl } from "@std/path";
 
 /**
  * Construct the final DOM document for a page.
@@ -28,7 +28,23 @@ export async function buildDocument(
   const doc = parser.parseFromString("<html></html>", "text/html");
   if (!doc) throw new Error(`${pagePath}: invalid HTML`);
 
-  const templatesUsed = await applyTemplates(
+  // Track template dependencies, including the blog content template when used
+  const templatesUsed = [];
+
+  // Apply blog content template to pages under /blog/ directory
+  const relPath = relative(siteDir, pagePath).replace(/\\/g, "/");
+  if (relPath.startsWith("blog/")) {
+    const blogModule = await importTemplate(
+      "blog",
+      "default",
+      root,
+      siteDir,
+      templatesUsed,
+    );
+    page.html = blogModule.render({ html: page.html });
+  }
+
+  const moreTemplates = await applyTemplates(
     doc,
     page,
     linksManager.data,
@@ -36,6 +52,7 @@ export async function buildDocument(
     root,
     siteDir,
   );
+  templatesUsed.push(...moreTemplates);
 
   const body = doc.querySelector("body");
   if (!body) throw new Error(`${pagePath}: missing <body> element`);

--- a/tests/blog-template.test.js
+++ b/tests/blog-template.test.js
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Ensures blog pages use the blog content template while other
+ * templates like head, nav and footer are still rendered via front matter.
+ */
+import { renderPage } from "../lib/render-page.js";
+import { join, toFileUrl } from "@std/path";
+import { DOMParser } from "@b-fuze/deno-dom";
+
+/**
+ * Assert that a condition is truthy.
+ * @param {unknown} cond Condition to evaluate.
+ * @param {string} [msg] Optional error message.
+ */
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+/**
+ * Assert that two values are deeply equal.
+ * @param {unknown} a First value.
+ * @param {unknown} b Second value.
+ */
+function assertEquals(a, b) {
+  const da = JSON.stringify(a);
+  const db = JSON.stringify(b);
+  if (da !== db) throw new Error(`Expected ${db}, got ${da}`);
+}
+
+Deno.test("blog pages render with blog template and other templates", async () => {
+  const root = await Deno.makeTempDir();
+  const rootUrl = toFileUrl(root + "/");
+  const siteDir = join(root, "mysite");
+  const distDir = join(root, "dist");
+  await Deno.mkdir(siteDir, { recursive: true });
+  await Deno.mkdir(distDir, { recursive: true });
+
+  await Deno.writeTextFile(
+    join(siteDir, "config.json"),
+    JSON.stringify({ distantDirectory: distDir }),
+  );
+
+  // Shared templates for head, nav, and footer
+  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "head", "default.js"),
+    "export function render({ frontMatter }) { return `<title>${frontMatter.title}</title>`; }",
+  );
+
+  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "nav", "default.js"),
+    "export function render() { return `<nav>Nav</nav>`; }",
+  );
+
+  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "templates", "footer", "default.js"),
+    "export function render() { return `<footer>Footer</footer>`; }",
+  );
+
+  // Blog markdown page with headings to generate a table of contents
+  const pagePath = join(siteDir, "blog", "post.md");
+  await Deno.mkdir(join(siteDir, "blog"), { recursive: true });
+  const md =
+    `title = "Blog Post"\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n#---#\n## Section 1\nContent`;
+  await Deno.writeTextFile(pagePath, md);
+
+  await renderPage(pagePath, rootUrl);
+
+  const outPath = join(distDir, "blog", "post.html");
+  const html = await Deno.readTextFile(outPath);
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+  assert(doc);
+  assertEquals(doc.querySelector("title")?.textContent, "Blog Post");
+  assertEquals(doc.querySelector("nav")?.textContent, "Nav");
+  assertEquals(doc.querySelector("footer")?.textContent, "Footer");
+  const link = doc.querySelector("main ul li a");
+  assert(link && link.getAttribute("href") === "#section-1");
+  assert(doc.querySelector("main h2")?.getAttribute("id") === "section-1");
+});

--- a/tests/render-page.test.js
+++ b/tests/render-page.test.js
@@ -106,7 +106,7 @@ Deno.test("renderPage renders page and updates links", async () => {
   });
 
   const depRec = pageDeps.get(pagePath);
-  assertEquals(depRec.templates.size, 3);
+  assertEquals(depRec.templates.size, 4);
   assert(depRec.svgs.has(join(siteDir, "src-svg", "ui", "check.svg")));
   assert(deps?.scriptsUsed.includes(inlineScriptPath));
   assert(depRec.scripts.has(inlineScriptPath));


### PR DESCRIPTION
## Summary
- automatically render content under `/blog/` with blog template
- add tests for blog template rendering and update dependencies tracking

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_68aa03efd410833182cd7d219a68af0d