### PR TITLE
feat: add rss feed generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kobra Kreator 🐍
 
-*A lightning‑fast, template‑driven static‑site generator built with **Deno***
+_A lightning‑fast, template‑driven static‑site generator built with **Deno**_
 
 ---
 
@@ -13,6 +13,7 @@
 | **Hot‑reload watcher**                   | Edits propagate instantly to your output directory        |
 | **Smart SVG tags** (`<icon>` / `<logo>`) | Drop SVGs straight into HTML and keep full CSS/JS control |
 | **TOML front‑matter & JS templates**     | Mix static content with dynamic head/nav/footer rendering |
+| **RSS feed generator**                   | Produce an automatic RSS feed for blog posts              |
 
 ---
 
@@ -32,9 +33,11 @@ curl -fsSL https://deno.land/install.sh | sh
 # 4 – Open `dist/` (or the path you set in each site’s config.json) in your browser
 ```
 
-> **Tip:** The first run performs a full build, then keeps watching `/src` (including any site templates) and `/templates` for changes.
+> **Tip:** The first run performs a full build, then keeps watching `/src`
+> (including any site templates) and `/templates` for changes.
 
-Want to work with Codex? Follow this guideline to setup environment [Codex Environement](https://github.com/KobraRocks/knowledge-base/blob/main/codex-with-deno.md)
+Want to work with Codex? Follow this guideline to setup environment
+[Codex Environement](https://github.com/KobraRocks/knowledge-base/blob/main/codex-with-deno.md)
 
 ## CLI Usage 🧰
 
@@ -44,7 +47,8 @@ Run the generator from the repository root with Deno:
 deno run -A --import-map=import_map.json main.js
 ```
 
-By default, Kobra Kreator spawns a worker for each available CPU core. You can tweak the worker pool with `--workers` (or `-w`):
+By default, Kobra Kreator spawns a worker for each available CPU core. You can
+tweak the worker pool with `--workers` (or `-w`):
 
 ```bash
 deno run -A --import-map=import_map.json main.js --workers 4
@@ -95,7 +99,8 @@ Head there for deep dives and examples.
 
 ## Tutorials 🎓
 
-- [My First Project](tutorials/my-first-project.md) – a discovery‑style walkthrough that incrementally builds a site under `/src/my-project/`.
+- [My First Project](tutorials/my-first-project.md) – a discovery‑style
+  walkthrough that incrementally builds a site under `/src/my-project/`.
 
 ---
 
@@ -112,4 +117,3 @@ Head there for deep dives and examples.
 ## License 📝
 
 Licensed under the MIT License. See [`LICENSE`](LICENSE).
-

--- a/core/templates/feed/default.js
+++ b/core/templates/feed/default.js
@@ -1,0 +1,12 @@
+/**
+ * Render a single RSS feed item.
+ *
+ * @param {{ item: { title: string, link: string, description: string, date?: Date } }} params
+ * @returns {string} RSS item XML string.
+ */
+export function render({ item }) {
+  const pubDate = item.date
+    ? `<pubDate>${item.date.toUTCString()}</pubDate>`
+    : "";
+  return `<item>\n<title>${item.title}</title>\n<link>${item.link}</link>\n<description><![CDATA[${item.description}]]></description>\n${pubDate}\n</item>`;
+}

--- a/docs/05-templates-api.md
+++ b/docs/05-templates-api.md
@@ -2,11 +2,11 @@
 
 Templates are **plain ECMAScript modules** that can live under a site‑specific
 `/src/<domain>/templates/` directory or the shared `/templates/` directory. They
-generate reusable page fragments—`<head>`, `<nav>`, and `<footer>`—based on
-each page’s front‑matter and the site’s central `links.json`. When a template
-is missing in these locations, Kobra Kreator checks for a file with the **same
-name** under `/core/templates/`. If no matching core template exists, the build
-fails with an error.
+generate reusable page fragments—`<head>`, `<nav>`, `<footer>`—and RSS feed
+items based on each page’s front‑matter and the site’s central `links.json`.
+When a template is missing in these locations, Kobra Kreator checks for a file
+with the **same name** under `/core/templates/`. If no matching core template
+exists, the build fails with an error.
 
 > **TL;DR**: export a `render()` function that returns an HTML string.
 
@@ -22,6 +22,8 @@ fails with an error.
     default.js
   footer/
     default.js
+  feed/
+    default.js
 
 /templates/                     # shared across sites
   head/
@@ -30,11 +32,13 @@ fails with an error.
     default.js
   footer/
     default.js
+  feed/
+    default.js
 ```
 
-_The generator maps the `frontMatter.templates.X` key to
-`templates/X/<NAME>.js` within the current site, then falls back to the project
-`/templates/` directory and finally `/core/templates/`._
+_The generator maps the `frontMatter.templates.X` key to `templates/X/<NAME>.js`
+within the current site, then falls back to the project `/templates/` directory
+and finally `/core/templates/`._
 
 ---
 
@@ -124,6 +128,17 @@ export function render({ links }) {
 }
 ```
 
+### 3.4 Feed / `default.js`
+
+```javascript
+export function render({ item }) {
+  const pubDate = item.date
+    ? `<pubDate>${item.date.toUTCString()}</pubDate>`
+    : "";
+  return `<item>\n<title>${item.title}</title>\n<link>${item.link}</link>\n<description><![CDATA[${item.description}]]></description>\n${pubDate}\n</item>`;
+}
+```
+
 ---
 
 ## 4. Access to utilities (planned)
@@ -139,9 +154,10 @@ parameter or named import.
 
 - If a template **throws**, the build logs the error and halts—better fail fast
   than produce broken markup.
- - Missing template file in the site directory → loads `/templates/<slot>/<name>.js`.
- - Still missing → loads `/core/templates/<slot>/<name>.js`.
- - Missing in all locations → build fails with an error.
+- Missing template file in the site directory → loads
+  `/templates/<slot>/<name>.js`.
+- Still missing → loads `/core/templates/<slot>/<name>.js`.
+- Missing in all locations → build fails with an error.
 
 ---
 

--- a/lib/generate-feed.js
+++ b/lib/generate-feed.js
@@ -1,0 +1,76 @@
+import { basename, join, relative } from "@std/path";
+import { walk } from "@std/fs/walk";
+import { parsePage } from "./parse-page.js";
+import { importTemplate } from "./apply-templates.js";
+import { logWithEmoji } from "./emoji.js";
+import { toHref } from "./manage-links.js";
+
+/**
+ * Generate an RSS feed for all posts under the site's `blog` directory.
+ *
+ * Each blog post must contain front matter with at least a `title` and
+ * `[templates]` table so it can be parsed by {@link parsePage}. The resulting
+ * feed is written to `blog/feed.xml` inside the site's distant directory.
+ *
+ * @param {string} siteDir Absolute path to the site's root directory.
+ * @param {{distantDirectory: string, prettyUrls?: boolean, siteUrl?: string, title?: string, description?: string}} config
+ *        Site configuration object.
+ * @returns {Promise<void>} Resolves when the feed has been generated.
+ */
+export async function generateFeed(siteDir, config) {
+  const blogDir = join(siteDir, "blog");
+  const distDir = String(config.distantDirectory);
+  const pretty = Boolean(config.prettyUrls);
+
+  /** @type {{title: string, description: string, link: string, date?: Date}[]} */
+  const items = [];
+
+  try {
+    for await (
+      const entry of walk(blogDir, {
+        exts: [".html", ".md"],
+        includeDirs: false,
+      })
+    ) {
+      const page = await parsePage(entry.path);
+      const rel = relative(siteDir, entry.path).replace(/\\/g, "/");
+      const link = toHref(rel, pretty);
+      items.push({
+        title: String(page.frontMatter.title),
+        description: String(page.frontMatter.description || ""),
+        link: `${config.siteUrl || ""}${link}`,
+        date: page.frontMatter.date
+          ? new Date(String(page.frontMatter.date))
+          : undefined,
+      });
+    }
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      // No blog directory – nothing to do.
+      return;
+    }
+    throw err;
+  }
+
+  // Sort newest first based on publication date when available.
+  items.sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0));
+
+  const module = await importTemplate(
+    "feed",
+    "default",
+    new URL("..", import.meta.url),
+    siteDir,
+  );
+  const itemsXml = items.map((item) => module.render({ item })).join("");
+
+  const channelTitle = config.title || basename(siteDir);
+  const channelLink = config.siteUrl || "";
+  const channelDescription = config.description || "";
+  const feedXml =
+    `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n<channel>\n<title>${channelTitle}</title>\n<link>${channelLink}</link>\n<description>${channelDescription}</description>\n${itemsXml}\n</channel>\n</rss>`;
+
+  const feedPath = join(distDir, "blog", "feed.xml");
+  await Deno.mkdir(join(distDir, "blog"), { recursive: true });
+  await Deno.writeTextFile(feedPath, feedXml);
+  logWithEmoji("create", `RSS feed written to ${feedPath}`);
+}

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,4 +1,4 @@
-import { join, relative, basename, dirname } from "@std/path";
+import { basename, dirname, join, relative } from "@std/path";
 import { parsePage } from "./parse-page.js";
 import { logWithEmoji } from "./emoji.js";
 import { findSiteRoot, loadConfig } from "./load-config.js";
@@ -9,6 +9,7 @@ import { buildDocument } from "./build-document.js";
 import { toOutRel, writeOutput } from "./write-output.js";
 import { applyFrontMatterHandlers } from "./front-matter-handlers.js";
 import { convert } from "./conversion-registry.js";
+import { generateFeed } from "./generate-feed.js";
 
 // Register built-in converters
 import "../plugins/markdown.js";
@@ -120,7 +121,18 @@ export async function postProcess(doc, context) {
     await fn(doc, context);
   }
 
-  await writeOutput(doc, context.path, context.siteDir, context.distant, context.pretty);
+  await writeOutput(
+    doc,
+    context.path,
+    context.siteDir,
+    context.distant,
+    context.pretty,
+  );
+
+  const rel = relative(context.siteDir, context.path).replace(/\\/g, "/");
+  if (rel.startsWith("blog/")) {
+    await generateFeed(context.siteDir, context.config);
+  }
 }
 
 /**
@@ -155,7 +167,12 @@ export async function renderPage(path, root = new URL("..", import.meta.url)) {
       const { siteDir, config } = await loadConfig(original);
       const pretty = Boolean(config.prettyUrls);
       const page = { frontMatter: {} };
-      const { linksChanged } = await manageLinks(page, siteDir, original, pretty);
+      const { linksChanged } = await manageLinks(
+        page,
+        siteDir,
+        original,
+        pretty,
+      );
       await removePage(original);
       return {
         pagePath: original,

--- a/tests/generate-feed.test.js
+++ b/tests/generate-feed.test.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Tests RSS feed generation from blog posts.
+ */
+import { generateFeed } from "../lib/generate-feed.js";
+import { join } from "@std/path";
+
+/**
+ * Assert that a condition is truthy.
+ * @param {unknown} cond Condition to evaluate.
+ * @param {string} [msg] Optional error message.
+ */
+function assert(cond, msg = "Assertion failed") {
+  if (!cond) throw new Error(msg);
+}
+
+Deno.test("generateFeed creates feed.xml from blog posts", async () => {
+  const root = await Deno.makeTempDir();
+  const siteDir = join(root, "mysite");
+  const distDir = join(root, "dist");
+  await Deno.mkdir(join(siteDir, "blog"), { recursive: true });
+
+  const config = {
+    distantDirectory: distDir,
+    siteUrl: "https://example.com",
+    title: "My Blog",
+  };
+
+  const postA =
+    `title = "First"\ndate = "2024-01-01"\n[templates]\nhead = "default"\n#---#\nA`;
+  await Deno.writeTextFile(join(siteDir, "blog", "a.md"), postA);
+  const postB =
+    `title = "Second"\ndate = "2024-02-01"\n[templates]\nhead = "default"\n#---#\nB`;
+  await Deno.writeTextFile(join(siteDir, "blog", "b.md"), postB);
+
+  await generateFeed(siteDir, config);
+
+  const feedPath = join(distDir, "blog", "feed.xml");
+  const xml = await Deno.readTextFile(feedPath);
+  assert(xml.includes("<title>My Blog</title>"));
+  const first = xml.indexOf("<title>Second</title>");
+  const second = xml.indexOf("<title>First</title>");
+  assert(first > -1 && second > -1 && first < second);
+});


### PR DESCRIPTION
## Summary
- generate RSS feed from blog posts with new feed template
- integrate feed generation into render pipeline
- document feed templates and add README note

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68aa32eb303083318718e9af42fe071c