### PR TITLE
feat: track generated files with sqlite

### DIFF
--- a/docs/09-watch-rules.md
+++ b/docs/09-watch-rules.md
@@ -70,7 +70,9 @@ any pages that include them.
 <!-- TODO: confirm whether `.ico` should trigger copy or be ignored. Current spec lists it in watch list. -->
 
 When a page or asset is **removed**, its counterpart in `distantDirectory` is
-deleted to keep the output tree in sync.
+deleted to keep the output tree in sync. Paths written to the distant
+directory are recorded in a project‑level SQLite database (`kobra.db`) so that
+removing a record also deletes the corresponding file.
 
 ---
 

--- a/import_map.json
+++ b/import_map.json
@@ -7,6 +7,7 @@
     "@std/testing/mock": "https://deno.land/std@0.224.0/testing/mock.ts",
     "@std/toml": "https://deno.land/std@0.224.0/toml/mod.ts",
     "@b-fuze/deno-dom": "npm:linkedom",
-    "@kobrarock/deno-cwebp":"jsr:@kobrarocks/deno-cwebp"
+    "@kobrarock/deno-cwebp":"jsr:@kobrarocks/deno-cwebp",
+    "@db/sqlite": "jsr:@db/sqlite"
   }
 }

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -3,6 +3,7 @@ import { SRC_ASSET_EXTENSIONS } from "./extension-whitelist.js";
 import { hashAssetName } from "./hash-asset.js";
 import { getEmoji } from "./emoji.js";
 import { findSiteRoot } from "./load-config.js";
+import { trackFile, untrackFile } from "./file-tracker.js";
 
 /**
  * Copy an asset from the source tree to its distant output directory.
@@ -58,11 +59,7 @@ export async function copyAsset(path) {
     const outDir = join(distant, dirRel);
     // Remove any existing un-hashed asset to avoid stale files.
     const unhashed = join(outDir, `${base}${ext}`);
-    try {
-      await Deno.remove(unhashed);
-    } catch (err) {
-      if (!(err instanceof Deno.errors.NotFound)) throw err;
-    }
+    await untrackFile(siteDir, unhashed);
     try {
       for await (const entry of Deno.readDir(outDir)) {
         if (
@@ -71,7 +68,7 @@ export async function copyAsset(path) {
           entry.name.endsWith(ext) &&
           entry.name !== hashed
         ) {
-          await Deno.remove(join(outDir, entry.name));
+          await untrackFile(siteDir, join(outDir, entry.name));
         }
       }
     } catch (err) {
@@ -85,6 +82,7 @@ export async function copyAsset(path) {
   const outPath = join(distant, outRel);
   await Deno.mkdir(dirname(outPath), { recursive: true });
   await Deno.copyFile(srcPath, outPath);
+  trackFile(siteDir, outPath);
 }
 
 /**
@@ -111,11 +109,7 @@ export async function removeAsset(path) {
     const outDir = join(distant, dirRel);
     // Remove the un-hashed file before clearing hashed variants.
     const unhashed = join(outDir, `${base}${ext}`);
-    try {
-      await Deno.remove(unhashed);
-    } catch (err) {
-      if (!(err instanceof Deno.errors.NotFound)) throw err;
-    }
+    await untrackFile(siteDir, unhashed);
     try {
       for await (const entry of Deno.readDir(outDir)) {
         if (
@@ -123,7 +117,7 @@ export async function removeAsset(path) {
           entry.name.startsWith(`${base}.`) &&
           entry.name.endsWith(ext)
         ) {
-          await Deno.remove(join(outDir, entry.name));
+          await untrackFile(siteDir, join(outDir, entry.name));
         }
       }
     } catch (err) {
@@ -132,9 +126,5 @@ export async function removeAsset(path) {
     return;
   }
   const outPath = join(distant, rel);
-  try {
-    await Deno.remove(outPath);
-  } catch (err) {
-    if (!(err instanceof Deno.errors.NotFound)) throw err;
-  }
+  await untrackFile(siteDir, outPath);
 }

--- a/lib/copy-asset.test.js
+++ b/lib/copy-asset.test.js
@@ -2,6 +2,7 @@ import { copyAsset, removeAsset } from "./copy-asset.js";
 import { hashAssetName } from "./hash-asset.js";
 import { assert, assertEquals } from "@std/assert";
 import { dirname, join } from "@std/path";
+import { Database } from "@db/sqlite";
 
 Deno.test("copyAsset preserves relative path", async () => {
   const root = await Deno.makeTempDir();
@@ -116,6 +117,31 @@ Deno.test(
     assertEquals(exists, false);
   },
 );
+
+Deno.test("copyAsset records and removeAsset cleans sqlite", async () => {
+  const root = await Deno.makeTempDir();
+  const distant = join(root, "dist");
+  await Deno.writeTextFile(
+    join(root, "config.json"),
+    JSON.stringify({ distantDirectory: distant }),
+  );
+  const srcFile = join(root, "css", "style.css");
+  await Deno.mkdir(dirname(srcFile), { recursive: true });
+  await Deno.writeTextFile(srcFile, "body{}");
+  await copyAsset(srcFile);
+  const outFile = join(distant, "css", "style.css");
+  const db = new Database(join(Deno.cwd(), "kobra.db"));
+  let stmt = db.prepare("SELECT path FROM tracked_files WHERE path = ?");
+  let rows = stmt.all([outFile]);
+  assertEquals(rows.length, 1);
+  stmt.finalize();
+  await removeAsset(srcFile);
+  stmt = db.prepare("SELECT path FROM tracked_files WHERE path = ?");
+  rows = stmt.all([outFile]);
+  assertEquals(rows.length, 0);
+  stmt.finalize();
+  db.close();
+});
 
 async function fileExists(path) {
   try {

--- a/lib/file-tracker.js
+++ b/lib/file-tracker.js
@@ -1,0 +1,58 @@
+import { Database } from "@db/sqlite";
+import { fromFileUrl } from "@std/path";
+
+/**
+ * SQLite-backed tracker for files written to distant directories.
+ * Records absolute file paths per site so stale files can be cleaned.
+ *
+ * @module file-tracker
+ */
+const dbPath = fromFileUrl(new URL("../kobra.db", import.meta.url));
+const db = new Database(dbPath);
+db.exec(
+  "CREATE TABLE IF NOT EXISTS tracked_files (site TEXT NOT NULL, path TEXT NOT NULL, PRIMARY KEY (site, path))",
+);
+
+/**
+ * Record a file for a given site in the tracking database.
+ *
+ * @param {string} siteDir Absolute path to the site directory.
+ * @param {string} filePath Absolute path to the file within the distant directory.
+ */
+export function trackFile(siteDir, filePath) {
+  db.exec(
+    "INSERT OR REPLACE INTO tracked_files (site, path) VALUES (?, ?)",
+    [siteDir, filePath],
+  );
+}
+
+/**
+ * Remove a tracked file entry and delete the file from disk.
+ *
+ * @param {string} siteDir Absolute path to the site directory.
+ * @param {string} filePath Absolute path to the file within the distant directory.
+ * @returns {Promise<void>} Resolves when the file is removed.
+ */
+export async function untrackFile(siteDir, filePath) {
+  db.exec("DELETE FROM tracked_files WHERE site = ? AND path = ?", [
+    siteDir,
+    filePath,
+  ]);
+  try {
+    await Deno.remove(filePath);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+}
+
+/**
+ * Retrieve all tracked files for a site.
+ *
+ * @param {string} siteDir Absolute path to the site directory.
+ * @returns {string[]} List of absolute file paths currently tracked.
+ */
+export function getTrackedFiles(siteDir) {
+  const stmt = db.prepare("SELECT path FROM tracked_files WHERE site = ?");
+  const rows = stmt.all([siteDir]);
+  return rows.map((row) => row.path);
+}

--- a/lib/file-tracker.test.js
+++ b/lib/file-tracker.test.js
@@ -1,0 +1,24 @@
+import { trackFile, untrackFile, getTrackedFiles } from "./file-tracker.js";
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+
+Deno.test("trackFile and untrackFile manage sqlite and filesystem", async () => {
+  const root = await Deno.makeTempDir();
+  const siteDir = root;
+  const dist = join(root, "dist");
+  await Deno.mkdir(dist, { recursive: true });
+  const filePath = join(dist, "note.txt");
+  await Deno.writeTextFile(filePath, "hi");
+  trackFile(siteDir, filePath);
+  let tracked = getTrackedFiles(siteDir);
+  assertEquals(tracked.includes(filePath), true);
+  await untrackFile(siteDir, filePath);
+  tracked = getTrackedFiles(siteDir);
+  assertEquals(tracked.includes(filePath), false);
+  try {
+    await Deno.stat(filePath);
+    throw new Error("file still exists");
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+});

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -7,6 +7,7 @@ import { processModules } from "./process-modules.js";
 import { manageLinks } from "./manage-links.js";
 import { buildDocument } from "./build-document.js";
 import { toOutRel, writeOutput } from "./write-output.js";
+import { untrackFile } from "./file-tracker.js";
 import { applyFrontMatterHandlers } from "./front-matter-handlers.js";
 import { convert } from "./conversion-registry.js";
 import { generateFeed } from "./generate-feed.js";
@@ -230,9 +231,5 @@ export async function removePage(path) {
   const rel = relative(siteDir, path).replace(/\\/g, "/");
   const outRel = toOutRel(rel, Boolean(config.prettyUrls));
   const outPath = join(distant, outRel);
-  try {
-    await Deno.remove(outPath);
-  } catch (err) {
-    if (!(err instanceof Deno.errors.NotFound)) throw err;
-  }
+  await untrackFile(siteDir, outPath);
 }

--- a/lib/render-page.test.js
+++ b/lib/render-page.test.js
@@ -1,6 +1,8 @@
 import { removePage } from "./render-page.js";
+import { trackFile } from "./file-tracker.js";
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
+import { Database } from "@db/sqlite";
 
 Deno.test("removePage deletes rendered file", async () => {
   const root = await Deno.makeTempDir();
@@ -14,9 +16,16 @@ Deno.test("removePage deletes rendered file", async () => {
   const outFile = join(distant, "index.html");
   await Deno.mkdir(distant, { recursive: true });
   await Deno.writeTextFile(outFile, "content");
+  trackFile(root, outFile);
   await removePage(srcFile);
   const exists = await fileExists(outFile);
   assertEquals(exists, false);
+  const db = new Database(join(Deno.cwd(), "kobra.db"));
+  const stmt = db.prepare("SELECT path FROM tracked_files WHERE path = ?");
+  const rows = stmt.all([outFile]);
+  assertEquals(rows.length, 0);
+  stmt.finalize();
+  db.close();
 });
 
 Deno.test("removePage deletes rendered file when prettyUrls enabled", async () => {

--- a/lib/write-output.js
+++ b/lib/write-output.js
@@ -1,4 +1,5 @@
 import { dirname, join, relative } from "@std/path";
+import { trackFile } from "./file-tracker.js";
 
 /**
  * Write the rendered HTML document to its destination and format it.
@@ -27,6 +28,8 @@ export async function writeOutput(doc, path, siteDir, distant, pretty) {
   if (code !== 0) {
     throw new Error(`${outPath}: ${new TextDecoder().decode(stderr).trim()}`);
   }
+
+  trackFile(siteDir, outPath);
 }
 
 /**


### PR DESCRIPTION
## Summary
- persist generated file paths in project-level SQLite database
- automatically track and remove assets and pages via database
- document SQLite-driven cleanup process

## Testing
- `deno test lib/file-tracker.test.js lib/copy-asset.test.js lib/render-page.test.js -A --import-map=import_map.json --unsafely-ignore-certificate-errors`
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors` *(failed: watch processes only whitelisted asset file types running >4m)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3cfd6d7083319d1cc843c7a5139d