### PR TITLE
feat: track source files

### DIFF
--- a/lib/source-file-tracker.js
+++ b/lib/source-file-tracker.js
@@ -1,0 +1,94 @@
+import { Database } from "@db/sqlite";
+import { fromFileUrl } from "@std/path";
+import { walk } from "@std/fs/walk";
+import { getEmoji } from "./emoji.js";
+
+/**
+ * SQLite-backed tracker for source files under `src/` and `templates/`.
+ * Records modification times to detect added, updated, or removed files
+ * between runs so only affected pages are processed.
+ *
+ * @module source-file-tracker
+ */
+const dbPath = fromFileUrl(new URL("../kobra.db", import.meta.url));
+const db = new Database(dbPath);
+db.exec(
+  "CREATE TABLE IF NOT EXISTS source_files (path TEXT PRIMARY KEY, mtime TEXT NOT NULL)",
+);
+
+/**
+ * Walk a directory and compare files to records in the tracking database.
+ *
+ * @param {string} root Absolute path to the directory to scan.
+ * @returns {Promise<{added: [string, number][], modified: [string, number][], removed: string[]}>} File changes.
+ */
+export async function diffSourceFiles(root) {
+  const known = new Map();
+  const rows = db.prepare("SELECT path, mtime FROM source_files").all();
+  for (const r of rows) known.set(r.path, Number(r.mtime));
+
+  const seen = new Set();
+  const added = [];
+  const modified = [];
+
+  try {
+    for await (const entry of walk(root, { includeDirs: false })) {
+      const stat = await Deno.stat(entry.path);
+      const mtime = stat.mtime ? stat.mtime.getTime() : 0;
+      seen.add(entry.path);
+      const prev = known.get(entry.path);
+      if (prev === undefined) {
+        console.log(`${getEmoji("create")} tracking new file -- ${entry.path}`);
+        added.push([entry.path, mtime]);
+      } else if (prev !== mtime) {
+        console.log(`${getEmoji("update")} detected change -- ${entry.path}`);
+        modified.push([entry.path, mtime]);
+      }
+    }
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+
+  const removed = [];
+  for (const [path] of known) {
+    if (!seen.has(path)) {
+      console.log(`${getEmoji("delete")} missing tracked file -- ${path}`);
+      removed.push(path);
+    }
+  }
+
+  return { added, modified, removed };
+}
+
+/**
+ * Record or update a file's modification time in the tracking database.
+ *
+ * @param {string} path Absolute path to the source file.
+ * @param {number} mtime Last modification timestamp.
+ */
+export function recordSourceFile(path, mtime) {
+  db.exec(
+    "INSERT OR REPLACE INTO source_files (path, mtime) VALUES (?, ?)",
+    [path, String(mtime)],
+  );
+}
+
+/**
+ * Remove a source file record from the tracking database.
+ *
+ * @param {string} path Absolute path to the source file.
+ */
+export function removeSourceFile(path) {
+  db.exec("DELETE FROM source_files WHERE path = ?", [path]);
+}
+
+/**
+ * Clear all tracked source file records. Primarily used in tests.
+ * @returns {void}
+ */
+export function clearSourceFiles() {
+  db.exec("DROP TABLE IF EXISTS source_files");
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS source_files (path TEXT PRIMARY KEY, mtime TEXT NOT NULL)",
+  );
+}

--- a/lib/source-file-tracker.test.js
+++ b/lib/source-file-tracker.test.js
@@ -1,0 +1,34 @@
+import { diffSourceFiles, recordSourceFile, removeSourceFile, clearSourceFiles } from "./source-file-tracker.js";
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+
+Deno.test("diffSourceFiles detects added, modified and removed files", async () => {
+  clearSourceFiles();
+  const root = await Deno.makeTempDir();
+  const filePath = join(root, "index.html");
+  await Deno.writeTextFile(filePath, "one");
+
+  let diff = await diffSourceFiles(root);
+  assertEquals(diff.added.length, 1);
+  recordSourceFile(filePath, diff.added[0][1]);
+
+  diff = await diffSourceFiles(root);
+  assertEquals(diff.added.length, 0);
+  assertEquals(diff.modified.length, 0);
+  assertEquals(diff.removed.length, 0);
+
+  await Deno.writeTextFile(filePath, "two");
+  diff = await diffSourceFiles(root);
+  assertEquals(diff.modified.length, 1);
+  recordSourceFile(filePath, diff.modified[0][1]);
+
+  await Deno.remove(filePath);
+  diff = await diffSourceFiles(root);
+  assertEquals(diff.removed, [filePath]);
+  removeSourceFile(filePath);
+
+  diff = await diffSourceFiles(root);
+  assertEquals(diff.added.length, 0);
+  assertEquals(diff.modified.length, 0);
+  assertEquals(diff.removed.length, 0);
+});

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -11,6 +11,11 @@ import {
 import { getEmoji } from "./emoji.js";
 import { classifyPath, reduceEvents } from "./fs-utils.js";
 import { WorkerPool } from "./worker-pool.js";
+import {
+  diffSourceFiles,
+  recordSourceFile,
+  removeSourceFile,
+} from "./source-file-tracker.js";
 
 /**
  * @type {WorkerPool}
@@ -242,6 +247,30 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
 
   const watchers = [srcWatcher, templatesWatcher];
 
+  // Initial synchronization of existing files before processing new events
+  const diffs = [
+    await diffSourceFiles(src),
+    await diffSourceFiles(templates),
+  ];
+  const startupTasks = new Map();
+  for (const { added, modified, removed } of diffs) {
+    for (const [p, m] of [...added, ...modified]) {
+      const kind = classifyPath(p);
+      const handler = createModifyHandlers[kind];
+      if (handler) handler(p, startupTasks);
+      recordSourceFile(p, m);
+    }
+    for (const p of removed) {
+      const kind = classifyPath(p);
+      const handler = removeHandlers[kind];
+      if (handler) handler(p, startupTasks);
+      removeSourceFile(p);
+    }
+  }
+  await Promise.all(
+    [...startupTasks.values()].map((t) => workerPool.push(...t)),
+  );
+
   const queue = [];
   let timer;
 
@@ -260,9 +289,18 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
       if (evtKind === "create" || evtKind === "modify") {
         const handler = createModifyHandlers[kind];
         if (handler) handler(path, tasks);
+        let mtime = 0;
+        try {
+          const stat = await Deno.stat(path);
+          if (stat.mtime) mtime = stat.mtime.getTime();
+        } catch (err) {
+          if (!(err instanceof Deno.errors.NotFound)) throw err;
+        }
+        recordSourceFile(path, mtime);
       } else if (evtKind === "remove") {
         const handler = removeHandlers[kind];
         if (handler) handler(path, tasks);
+        removeSourceFile(path);
       }
     }
     await Promise.all(


### PR DESCRIPTION
## Summary
- track and diff source files using SQLite
- sync initial file state before watching
- persist source file changes for incremental rebuilds

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors --ignore=tests/e2e/watch-file-types.test.js` *(hangs on watch-inline-scripts test)*

------
https://chatgpt.com/codex/tasks/task_e_68ab011f5d588331899e6423276ff331