### PR TITLE
feat: improve SQLite concurrency

### DIFF
--- a/lib/file-tracker.js
+++ b/lib/file-tracker.js
@@ -9,6 +9,9 @@ import { fromFileUrl } from "@std/path";
  */
 const dbPath = fromFileUrl(new URL("../kobra.db", import.meta.url));
 const db = new Database(dbPath);
+// Configure SQLite to allow concurrent readers and wait for file locks.
+db.exec("PRAGMA journal_mode=WAL");
+db.exec("PRAGMA busy_timeout = 5000");
 db.exec(
   "CREATE TABLE IF NOT EXISTS tracked_files (site TEXT NOT NULL, path TEXT NOT NULL, PRIMARY KEY (site, path))",
 );


### PR DESCRIPTION
## Summary
- initialize file tracker database with WAL mode and busy timeout to support concurrent access

## Testing
- `deno run -A --import-map=import_map.json --unsafely-ignore-certificate-errors main.js`
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68ab092dac1c8331b06b19fbb36808a4