### PR TITLE
refactor: stabilize full build worker handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,54 +4,7 @@ import { parse } from "@std/flags";
 import { walk } from "@std/fs/walk";
 import { watch } from "./lib/watch.js";
 import { recordPageDeps } from "./lib/page-deps.js";
-
-/**
- * Create a worker pool for rendering tasks.
- *
- * @param {number} size Number of workers to spawn.
- * @returns {{push: (task: object) => Promise<void>}} Pool interface.
- */
-function createPool(size) {
-  const workerUrl = new URL("./lib/worker-task.js", import.meta.url);
-  const idle = [];
-  const queue = [];
-  const jobs = new Map();
-  let id = 0;
-
-  for (let i = 0; i < size; i++) {
-    const w = new Worker(workerUrl.href, { type: "module" });
-    w.onmessage = (e) => {
-      const job = jobs.get(e.data.id);
-      jobs.delete(e.data.id);
-      if (e.data.error) job.reject(new Error(e.data.error));
-      else job.resolve();
-      if (e.data.deps) {
-        recordPageDeps(e.data.deps);
-      }
-      idle.push(w);
-      runNext();
-    };
-    idle.push(w);
-  }
-
-  function runNext() {
-    if (queue.length === 0 || idle.length === 0) return;
-    const w = idle.pop();
-    const job = queue.shift();
-    jobs.set(job.data.id, job);
-    w.postMessage(job.data);
-  }
-
-  function push(task) {
-    return new Promise((resolve, reject) => {
-      const data = { ...task, id: ++id };
-      queue.push({ data, resolve, reject });
-      runNext();
-    });
-  }
-
-  return { push };
-}
+import { WorkerPool } from "./lib/worker-pool.js";
 
 /**
  * Render all pages using a pool of workers.
@@ -61,17 +14,36 @@ function createPool(size) {
  */
 async function fullBuild(workers) {
   const root = new URL("./src", import.meta.url);
-  const pool = createPool(workers);
+  // The WorkerPool handles worker lifecycle and propagates errors so the
+  // build process does not hang if a worker crashes.
+  const pool = new WorkerPool(
+    new URL("./lib/worker-task.js", import.meta.url).href,
+    workers,
+  );
   const tasks = [];
   try {
     for await (
       const entry of walk(root, { exts: [".html"], includeDirs: false })
     ) {
-      tasks.push(pool.push({ type: "render", path: entry.path }));
+      tasks.push(
+        pool.push(
+          { type: "render", path: entry.path },
+          [
+            (e) => {
+              if (e.data.deps) {
+                recordPageDeps(e.data.deps);
+              }
+            },
+          ],
+        ),
+      );
     }
     await Promise.all(tasks);
   } catch (err) {
     if (!(err instanceof Deno.errors.NotFound)) throw err;
+  } finally {
+    // Ensure all workers are terminated to avoid locking subsequent runs.
+    pool.close();
   }
 }
 


### PR DESCRIPTION
## Summary
- Use shared `WorkerPool` for full build to avoid hanging workers
- Close worker pool after rendering to prevent locked startup

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`

------
https://chatgpt.com/codex/tasks/task_e_68ab0d08ad5083319bde63dbcea1b133