### PR TITLE
refactor: relocate sqlite database to user home

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -2,6 +2,7 @@
   "imports": {
     "@std/path": "https://deno.land/std@0.224.0/path/mod.ts",
     "@std/fs/walk": "https://deno.land/std@0.224.0/fs/walk.ts",
+    "@std/fs": "https://deno.land/std@0.224.0/fs/mod.ts",
     "@std/flags": "https://deno.land/std@0.224.0/flags/mod.ts",
     "@std/assert": "https://deno.land/std@0.224.0/assert/mod.ts",
     "@std/testing/mock": "https://deno.land/std@0.224.0/testing/mock.ts",

--- a/lib/copy-asset.test.js
+++ b/lib/copy-asset.test.js
@@ -2,7 +2,7 @@ import { copyAsset, removeAsset } from "./copy-asset.js";
 import { hashAssetName } from "./hash-asset.js";
 import { assert, assertEquals } from "@std/assert";
 import { dirname, join } from "@std/path";
-import { Database } from "@db/sqlite";
+import { getTrackedFiles } from "./file-tracker.js";
 
 Deno.test("copyAsset preserves relative path", async () => {
   const root = await Deno.makeTempDir();
@@ -118,30 +118,24 @@ Deno.test(
   },
 );
 
-Deno.test("copyAsset records and removeAsset cleans sqlite", async () => {
-  const root = await Deno.makeTempDir();
-  const distant = join(root, "dist");
-  await Deno.writeTextFile(
-    join(root, "config.json"),
-    JSON.stringify({ distantDirectory: distant }),
-  );
-  const srcFile = join(root, "css", "style.css");
-  await Deno.mkdir(dirname(srcFile), { recursive: true });
-  await Deno.writeTextFile(srcFile, "body{}");
-  await copyAsset(srcFile);
-  const outFile = join(distant, "css", "style.css");
-  const db = new Database(join(Deno.cwd(), "kobra.db"));
-  let stmt = db.prepare("SELECT path FROM tracked_files WHERE path = ?");
-  let rows = stmt.all([outFile]);
-  assertEquals(rows.length, 1);
-  stmt.finalize();
-  await removeAsset(srcFile);
-  stmt = db.prepare("SELECT path FROM tracked_files WHERE path = ?");
-  rows = stmt.all([outFile]);
-  assertEquals(rows.length, 0);
-  stmt.finalize();
-  db.close();
-});
+  Deno.test("copyAsset records and removeAsset cleans sqlite", async () => {
+    const root = await Deno.makeTempDir();
+    const distant = join(root, "dist");
+    await Deno.writeTextFile(
+      join(root, "config.json"),
+      JSON.stringify({ distantDirectory: distant }),
+    );
+    const srcFile = join(root, "css", "style.css");
+    await Deno.mkdir(dirname(srcFile), { recursive: true });
+    await Deno.writeTextFile(srcFile, "body{}");
+    await copyAsset(srcFile);
+    const outFile = join(distant, "css", "style.css");
+    let tracked = getTrackedFiles(root);
+    assertEquals(tracked.includes(outFile), true);
+    await removeAsset(srcFile);
+    tracked = getTrackedFiles(root);
+    assertEquals(tracked.includes(outFile), false);
+  });
 
 async function fileExists(path) {
   try {

--- a/lib/file-tracker.js
+++ b/lib/file-tracker.js
@@ -1,5 +1,6 @@
 import { Database } from "@db/sqlite";
-import { fromFileUrl } from "@std/path";
+import { join } from "@std/path";
+import { ensureDirSync } from "@std/fs";
 
 /**
  * SQLite-backed tracker for files written to distant directories.
@@ -7,7 +8,16 @@ import { fromFileUrl } from "@std/path";
  *
  * @module file-tracker
  */
-const dbPath = fromFileUrl(new URL("../kobra.db", import.meta.url));
+/**
+ * Path to the SQLite database tracking emitted files.
+ * Located in the user's home directory to ensure write access.
+ *
+ * @type {string}
+ */
+const homeDir = Deno.env.get("HOME") ?? Deno.cwd();
+const dbDir = join(homeDir, ".kobra");
+ensureDirSync(dbDir);
+const dbPath = join(dbDir, "kobra.db");
 const db = new Database(dbPath);
 // Configure SQLite to allow concurrent readers and wait for file locks.
 db.exec("PRAGMA journal_mode=WAL");

--- a/lib/render-page.test.js
+++ b/lib/render-page.test.js
@@ -1,8 +1,7 @@
 import { removePage } from "./render-page.js";
-import { trackFile } from "./file-tracker.js";
+import { trackFile, getTrackedFiles } from "./file-tracker.js";
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
-import { Database } from "@db/sqlite";
 
 Deno.test("removePage deletes rendered file", async () => {
   const root = await Deno.makeTempDir();
@@ -18,15 +17,11 @@ Deno.test("removePage deletes rendered file", async () => {
   await Deno.writeTextFile(outFile, "content");
   trackFile(root, outFile);
   await removePage(srcFile);
-  const exists = await fileExists(outFile);
-  assertEquals(exists, false);
-  const db = new Database(join(Deno.cwd(), "kobra.db"));
-  const stmt = db.prepare("SELECT path FROM tracked_files WHERE path = ?");
-  const rows = stmt.all([outFile]);
-  assertEquals(rows.length, 0);
-  stmt.finalize();
-  db.close();
-});
+    const exists = await fileExists(outFile);
+    assertEquals(exists, false);
+    const tracked = getTrackedFiles(root);
+    assertEquals(tracked.includes(outFile), false);
+  });
 
 Deno.test("removePage deletes rendered file when prettyUrls enabled", async () => {
   const root = await Deno.makeTempDir();


### PR DESCRIPTION
## Summary
- place file tracker database in user home to avoid permission issues
- register `@std/fs` in import map and ensure directory creation
- update tests to verify tracking via API rather than querying sqlite directly

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68ab2961b4608331a4600908a941e4af