### PR TITLE
fix: prevent sqlite disk errors for source file tracking

### DIFF
--- a/lib/source-file-tracker.js
+++ b/lib/source-file-tracker.js
@@ -1,5 +1,6 @@
 import { Database } from "@db/sqlite";
-import { fromFileUrl } from "@std/path";
+import { join } from "@std/path";
+import { ensureDirSync } from "@std/fs";
 import { walk } from "@std/fs/walk";
 import { getEmoji } from "./emoji.js";
 
@@ -10,8 +11,20 @@ import { getEmoji } from "./emoji.js";
  *
  * @module source-file-tracker
  */
-const dbPath = fromFileUrl(new URL("../kobra.db", import.meta.url));
+/**
+ * Location of the SQLite database. Placing it under the user's home
+ * directory ensures write access across environments.
+ *
+ * @type {string}
+ */
+const homeDir = Deno.env.get("HOME") ?? Deno.cwd();
+const dbDir = join(homeDir, ".kobra");
+ensureDirSync(dbDir);
+const dbPath = join(dbDir, "kobra.db");
 const db = new Database(dbPath);
+// Allow concurrent readers and wait when the database is locked.
+db.exec("PRAGMA journal_mode=WAL");
+db.exec("PRAGMA busy_timeout = 5000");
 db.exec(
   "CREATE TABLE IF NOT EXISTS source_files (path TEXT PRIMARY KEY, mtime TEXT NOT NULL)",
 );


### PR DESCRIPTION
## Summary
- locate source file tracking DB under user home for reliable writes
- enable WAL and busy timeout to avoid locking

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68ab2bf0674483318934570064b9a314