### PR TITLE
chore: extend full build test timeout

### DIFF
--- a/tests/e2e/full-build.test.js
+++ b/tests/e2e/full-build.test.js
@@ -17,9 +17,16 @@ Deno.test({
       // ignore if db does not exist
     }
 
+    /**
+     * Maximum time in milliseconds to wait for the build to complete.
+     * Can be overridden via the BUILD_TIMEOUT environment variable.
+     * @type {number}
+     */
+    const buildTimeoutMs = Number(Deno.env.get("BUILD_TIMEOUT") ?? "30000");
+
     const build = fullBuild(1);
     const timeout = new Promise((_, reject) =>
-      setTimeout(() => reject(new Error("build timeout")), 10000)
+      setTimeout(() => reject(new Error("build timeout")), buildTimeoutMs)
     );
     await Promise.race([build, timeout]);
 


### PR DESCRIPTION
## Summary
- allow configuring the full build test timeout via `BUILD_TIMEOUT` env var

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors tests/e2e/full-build.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab2f6d8bc08331b54cc062f1ec5780