### PR TITLE
refactor: run sequential build pipeline

### DIFF
--- a/lib/apply-templates.js
+++ b/lib/apply-templates.js
@@ -42,7 +42,7 @@ export async function importTemplate(
   }
 
   // 2. Shared project-level templates
-  moduleUrl = new URL(`templates/${slot}/${name}.js`, root);
+  moduleUrl = new URL(`shared/templates/${slot}/${name}.js`, root);
   try {
     module = await import(`${moduleUrl.href}?t=${Date.now()}`);
     used.push(fromFileUrl(moduleUrl));

--- a/lib/build-document.js
+++ b/lib/build-document.js
@@ -2,6 +2,7 @@ import { DOMParser } from "@b-fuze/deno-dom";
 import { applyTemplates, importTemplate } from "./apply-templates.js";
 import { inlineSvg } from "./inline-svg.js";
 import { join, relative, toFileUrl } from "@std/path";
+import { resolveDependency } from "./resolve-dependency.js";
 
 /**
  * Construct the final DOM document for a page.
@@ -67,20 +68,18 @@ export async function buildDocument(
   const scriptsUsed = [];
   for (const file of page.scripts.inline ?? []) {
     const scriptPath = join(siteDir, file);
-    let realPath;
-    try {
-      realPath = await Deno.realPath(scriptPath);
-    } catch {
-      realPath = scriptPath;
+    const resolved = await resolveDependency(file, siteDir);
+    if (!resolved) {
+      throw new Error(`${scriptPath}: inline script not found`);
     }
     let content;
     try {
-      content = await Deno.readTextFile(realPath);
+      content = await Deno.readTextFile(resolved);
     } catch (err) {
-      if (err instanceof Error) err.message = `${realPath}: ${err.message}`;
+      if (err instanceof Error) err.message = `${resolved}: ${err.message}`;
       throw err;
     }
-    scriptsUsed.push(realPath);
+    scriptsUsed.push(resolved);
     const script = doc.createElement("script");
     script.textContent = content;
     body.appendChild(script);

--- a/lib/copy-asset.js
+++ b/lib/copy-asset.js
@@ -32,19 +32,34 @@ export async function copyAsset(path) {
   try {
     await Deno.stat(srcPath);
   } catch (err) {
-    if (err instanceof Deno.errors.NotFound && ext === ".css") {
-      const fallback = fromFileUrl(
-        new URL(`../core/css/${rel}`, import.meta.url),
+    if (err instanceof Deno.errors.NotFound) {
+      const sharedFallback = fromFileUrl(
+        new URL(`../shared/${rel}`, import.meta.url),
       );
       try {
-        await Deno.stat(fallback);
-        srcPath = fallback;
+        await Deno.stat(sharedFallback);
+        srcPath = sharedFallback;
       } catch (err2) {
         if (err2 instanceof Deno.errors.NotFound) {
-          console.log(`${getEmoji("error")} CSS missing -- ${rel}`);
-          return;
+          const coreFallback = fromFileUrl(
+            new URL(`../core/${rel}`, import.meta.url),
+          );
+          try {
+            await Deno.stat(coreFallback);
+            srcPath = coreFallback;
+          } catch (err3) {
+            if (err3 instanceof Deno.errors.NotFound) {
+              const kind = ext === ".css" ? "CSS" : "ASSET";
+              console.log(
+                `${getEmoji("error")} ${kind} missing -- ${rel}`,
+              );
+              return;
+            }
+            throw err3;
+          }
+        } else {
+          throw err2;
         }
-        throw err2;
       }
     } else {
       throw err;

--- a/lib/fs-utils.test.js
+++ b/lib/fs-utils.test.js
@@ -17,7 +17,7 @@ Deno.test("classifyPath - identifies asset types", () => {
   assertEquals(classifyPath("/media/image.png"), "ASSET");
   assertEquals(classifyPath("/src/main.css"), "ASSET");
   assertEquals(classifyPath("/src-svg/icon.svg"), "SVG_INLINE");
-  assertEquals(classifyPath("/templates/component.js"), "TEMPLATE");
+  assertEquals(classifyPath("/shared/templates/component.js"), "TEMPLATE");
   assertEquals(classifyPath("/page.html"), "PAGE_HTML");
 });
 

--- a/lib/parse-page.js
+++ b/lib/parse-page.js
@@ -28,20 +28,35 @@ const FOOTER_LINK_KEYS = ["column", "label"];
  */
 
 /**
- * Parse an HTML file with TOML front-matter.
+ * Parse a page containing TOML front-matter.
  *
- * Splits the file at `#---#`, parses the first segment as TOML and validates
- * recognised keys. Unknown keys log a warning. Returns the parsed front-matter
- * alongside the remaining HTML.
+ * Accepts either a file path or an object specifying the path, raw content,
+ * and extension. When only a path is provided the file is read from disk. The
+ * file is split at `#---#`, the first segment is parsed as TOML, and the
+ * remaining segment becomes the HTML body. Markdown sources are converted to
+ * HTML when the extension is `.md` or `.markdown`.
  *
- * @param {string} raw content of the file being processed.
+ * @param {string | {path?: string, raw?: string, extension?: string}} input
+ *   Path or configuration object describing the page to parse.
  * @returns {Promise<ParsedPage>} Parsed front-matter and HTML content.
  */
-export async function parsePage({ 
-    path = "",
-    raw = "",  
-    extension = ".html" || ".md" || ".markdown"
-}) {
+export async function parsePage(input) {
+  let path = "";
+  let raw = "";
+  let extension = ".html";
+
+  if (typeof input === "string") {
+    path = input;
+  } else if (typeof input === "object" && input) {
+    ({ path = "", raw = "", extension = ".html" } = input);
+  }
+
+  if (!raw && path) {
+    raw = await Deno.readTextFile(path);
+    const dot = path.lastIndexOf(".");
+    if (dot !== -1) extension = path.slice(dot).toLowerCase();
+  }
+
   const separator = "#---#";
   const idx = raw.indexOf(separator);
   if (idx === -1) {
@@ -51,10 +66,9 @@ export async function parsePage({
   const rawContent = raw.slice(idx + separator.length);
 
   let html = rawContent;
-
   if (extension === ".md" || extension === ".markdown") {
-      html = markdownToHTML(rawContent);
-  }  
+    html = markdownToHTML(rawContent);
+  }
 
   let frontMatter = {};
   if (tomlText.length > 0) {
@@ -67,6 +81,7 @@ export async function parsePage({
       throw err;
     }
   }
+
   const extra = validateFrontMatter(frontMatter, path);
   return {
     frontMatter,

--- a/lib/process-css.js
+++ b/lib/process-css.js
@@ -1,7 +1,8 @@
-import { dirname, join, fromFileUrl } from "@std/path";
+import { dirname, join } from "@std/path";
 import { hashAssetName } from "./hash-asset.js";
 import { copyAsset } from "./copy-asset.js";
 import { getEmoji } from "./emoji.js";
+import { resolveDependency } from "./resolve-dependency.js";
 
 /**
  * Handle CSS references from page front matter.
@@ -18,38 +19,20 @@ export async function processCss(page, siteDir, hashAssets) {
     cssFiles.map(async (href) => {
       const relHref = href.startsWith("/") ? href.slice(1) : href;
       const abs = join(siteDir, relHref);
-      try {
-        const real = await Deno.realPath(abs);
-        cssUsed.push(real);
-        if (!hashAssets) return href;
-        const hashed = await hashAssetName(real);
-        const dirRel = dirname(relHref);
-        const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-          .replace(/\\/g, "/");
-        return href.startsWith("/") ? "/" + relPath : relPath;
-      } catch {
-        const corePath = fromFileUrl(
-          new URL(`../core/css/${relHref}`, import.meta.url),
-        );
-        try {
-          await Deno.stat(corePath);
-          cssUsed.push(abs);
-          if (hashAssets) {
-            const hashed = await hashAssetName(corePath);
-            const dirRel = dirname(relHref);
-            const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
-              .replace(/\\/g, "/");
-            await copyAsset(abs);
-            return href.startsWith("/") ? "/" + relPath : relPath;
-          }
-          await copyAsset(abs);
-          return href;
-        } catch {
-          console.log(`${getEmoji("error")} CSS missing -- ${relHref}`);
-          cssUsed.push(abs);
-          return href;
-        }
+      const resolved = await resolveDependency(relHref, siteDir);
+      if (!resolved) {
+        console.log(`${getEmoji("error")} CSS missing -- ${relHref}`);
+        cssUsed.push(abs);
+        return href;
       }
+      cssUsed.push(resolved);
+      await copyAsset(abs);
+      if (!hashAssets) return href;
+      const hashed = await hashAssetName(resolved);
+      const dirRel = dirname(relHref);
+      const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
+        .replace(/\\/g, "/");
+      return href.startsWith("/") ? "/" + relPath : relPath;
     }),
   );
   return cssUsed;

--- a/lib/process-modules.js
+++ b/lib/process-modules.js
@@ -1,5 +1,8 @@
 import { dirname, join } from "@std/path";
 import { hashAssetName } from "./hash-asset.js";
+import { copyAsset } from "./copy-asset.js";
+import { getEmoji } from "./emoji.js";
+import { resolveDependency } from "./resolve-dependency.js";
 
 /**
  * Handle module script references defined in front matter.
@@ -16,15 +19,16 @@ export async function processModules(page, siteDir, hashAssets) {
     moduleFiles.map(async (src) => {
       const relSrc = src.startsWith("/") ? src.slice(1) : src;
       const abs = join(siteDir, relSrc);
-      let real;
-      try {
-        real = await Deno.realPath(abs);
-      } catch {
-        real = abs;
+      const resolved = await resolveDependency(relSrc, siteDir);
+      if (!resolved) {
+        console.log(`${getEmoji("error")} MODULE missing -- ${relSrc}`);
+        modulesUsed.push(abs);
+        return src;
       }
-      modulesUsed.push(real);
+      modulesUsed.push(resolved);
+      await copyAsset(abs);
       if (!hashAssets) return src;
-      const hashed = await hashAssetName(abs);
+      const hashed = await hashAssetName(resolved);
       const dirRel = dirname(relSrc);
       const relPath = (dirRel === "." ? hashed : join(dirRel, hashed))
         .replace(/\\/g, "/");

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,4 +1,4 @@
-import { basename, dirname, join, relative } from "@std/path";
+import { basename, dirname, join, relative, toFileUrl } from "@std/path";
 import { parsePage } from "./parse-page.js";
 import { logWithEmoji } from "./emoji.js";
 import { findSiteRoot, loadConfig } from "./load-config.js";
@@ -65,6 +65,10 @@ export async function preProcess(page, context) {
   context.distant = distant;
   context.pretty = pretty;
   context.hashAssets = hashAssets;
+
+  if (!context.root) {
+    context.root = new URL("../", toFileUrl(siteDir + "/"));
+  }
 
   context.cssUsed = await processCss(page, siteDir, hashAssets);
   context.modulesUsed = await processModules(page, siteDir, hashAssets);

--- a/lib/resolve-dependency.js
+++ b/lib/resolve-dependency.js
@@ -1,0 +1,39 @@
+import { join, fromFileUrl } from "@std/path";
+
+/**
+ * Resolve a dependency path relative to the site, shared, then core directories.
+ *
+ * Searches for the file under the site's directory first. If not found, the
+ * `/shared` and `/core` folders are checked in order using the same relative
+ * path. Returns the first existing path or `undefined` when no match is
+ * located.
+ *
+ * @param {string} relPath Path relative to the root, e.g. `"css/style.css"`.
+ * @param {string} siteDir Absolute path to the site's root directory.
+ * @returns {Promise<string|undefined>} Resolved absolute file path or
+ * `undefined` if it does not exist in any location.
+ */
+export async function resolveDependency(relPath, siteDir) {
+  const sitePath = join(siteDir, relPath);
+  try {
+    return await Deno.realPath(sitePath);
+  } catch {
+    // fall through to shared/core lookup
+  }
+
+  const sharedPath = fromFileUrl(new URL(`../shared/${relPath}`, import.meta.url));
+  try {
+    await Deno.stat(sharedPath);
+    return sharedPath;
+  } catch {
+    // fall through
+  }
+
+  const corePath = fromFileUrl(new URL(`../core/${relPath}`, import.meta.url));
+  try {
+    await Deno.stat(corePath);
+    return corePath;
+  } catch {
+    return undefined;
+  }
+}

--- a/lib/resolve-dependency.test.js
+++ b/lib/resolve-dependency.test.js
@@ -1,0 +1,26 @@
+import { join } from "@std/path";
+import { assertEquals } from "@std/assert";
+import { resolveDependency } from "./resolve-dependency.js";
+
+Deno.test("resolveDependency prioritizes shared then core", async () => {
+  const siteDir = await Deno.makeTempDir({ dir: Deno.cwd() });
+  const rel = "css/resolve-test.css";
+  const sharedFile = join(Deno.cwd(), "shared", rel);
+  const coreFile = join(Deno.cwd(), "core", rel);
+
+  await Deno.mkdir(join(Deno.cwd(), "shared", "css"), { recursive: true });
+  await Deno.writeTextFile(sharedFile, "/* shared */");
+
+  let resolved = await resolveDependency(rel, siteDir);
+  assertEquals(resolved, sharedFile);
+
+  await Deno.remove(sharedFile);
+  await Deno.writeTextFile(coreFile, "/* core */");
+
+  resolved = await resolveDependency(rel, siteDir);
+  assertEquals(resolved, coreFile);
+
+  await Deno.remove(coreFile);
+  await Deno.remove(join(Deno.cwd(), "shared"), { recursive: true });
+  await Deno.remove(siteDir, { recursive: true });
+});

--- a/lib/source-file-tracker.test.js
+++ b/lib/source-file-tracker.test.js
@@ -17,6 +17,8 @@ Deno.test("diffSourceFiles detects added, modified and removed files", async () 
   assertEquals(diff.modified.length, 0);
   assertEquals(diff.removed.length, 0);
 
+  // Pause briefly to ensure the file modification time updates on all filesystems.
+  await new Promise((r) => setTimeout(r, 10));
   await Deno.writeTextFile(filePath, "two");
   diff = await diffSourceFiles(root);
   assertEquals(diff.modified.length, 1);

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -10,92 +10,83 @@ import {
 } from "./page-deps.js";
 import { getEmoji } from "./emoji.js";
 import { classifyPath, reduceEvents } from "./fs-utils.js";
-import { WorkerPool } from "./worker-pool.js";
 import {
   diffSourceFiles,
   recordSourceFile,
   removeSourceFile,
 } from "./source-file-tracker.js";
+import { removePage, renderPage } from "./render-page.js";
+import { copyAsset, removeAsset } from "./copy-asset.js";
 
 /**
- * @type {WorkerPool}
- */
-let workerPool;
-
-/**
- * Create a worker task that renders a page through the pipeline and records its
- * dependencies.
+ * Render a page and update dependency records.
  *
- * @param {string} path - Path to the page to render.
- * @returns {[import("./worker-pool.js").WorkerTask, Array<(e: MessageEvent) => void>]} Task and callbacks tuple.
-*/
-function workerProcessPage(path) {
-  return [
-    { type: "render", path },
-    [
-      (e) => {
-        const deps = e.data.deps;
-        recordPageDeps(deps);
-        // If navigation data changed, refresh other pages that reference links.json.
-        if (deps && deps.linksChanged) {
-          for (const page of pagesWithLinks()) {
-            if (page !== deps.pagePath) {
-              workerPool.push(...workerProcessPage(page));
-            }
-          }
+ * Re-renders pages that reference `links.json` if navigation data changes.
+ *
+ * @param {string} path Absolute path to the page file.
+ * @returns {Promise<void>} Resolves when rendering and dependency recording finish.
+ */
+async function renderAndRecord(path) {
+  const deps = await renderPage(path);
+  if (deps) {
+    recordPageDeps(deps);
+    if (deps.linksChanged) {
+      for (const page of pagesWithLinks()) {
+        if (page !== deps.pagePath) {
+          await renderAndRecord(page);
         }
-      },
-    ],
-  ];
-}
-
-/**
- * Schedule rendering of a page when its HTML changes.
- *
- * @param {string} path - Path to the page file.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
- */
-function handlePageHtml(path, tasks) {
-  tasks.set(path, workerProcessPage(path));
-}
-
-/**
- * Handle updates to a template file by re-rendering dependent pages.
- *
- * @param {string} path - Path to the template.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
- */
-function handleTemplateUpdate(path, tasks) {
-  console.log(`${getEmoji("update")} TEMPLATE UPDATED -- ${path}`);
-  for (const page of pagesUsingTemplate(path)) {
-    tasks.set(page, workerProcessPage(page));
+      }
+    }
   }
 }
 
 /**
- * Handle updates to an inline script by refreshing referencing pages.
+ * Queue a page for rendering when its source HTML changes.
  *
- * @param {string} path - Path to the inline script.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
+ * @param {string} path Path to the page file.
+ * @param {Set<string>} tasks Set collecting pages to render.
+ */
+function handlePageHtml(path, tasks) {
+  tasks.add(path);
+}
+
+/**
+ * Handle updates to template files by re-rendering dependent pages.
+ *
+ * @param {string} path Path to the template.
+ * @param {Set<string>} tasks Set collecting pages to render.
+ */
+function handleTemplateUpdate(path, tasks) {
+  console.log(`${getEmoji("update")} TEMPLATE UPDATED -- ${path}`);
+  for (const page of pagesUsingTemplate(path)) {
+    tasks.add(page);
+  }
+}
+
+/**
+ * Handle updates to inline scripts by refreshing referencing pages.
+ *
+ * @param {string} path Path to the inline script.
+ * @param {Set<string>} tasks Set collecting pages to render.
  */
 function handleInlineScriptUpdate(path, tasks) {
   console.log(`${getEmoji("update")} INLINE SCRIPT UPDATED -- ${path}`);
   const pages = pagesUsingScript(path);
   if (pages.length === 0) {
-    console.log(`  ${getEmoji("warning")} no pages reference this inline script`);
+    console.log(
+      `  ${getEmoji("warning")} no pages reference this inline script`,
+    );
     return;
   }
-  for (const page of pages) {
-    tasks.set(page, workerProcessPage(page));
-  }
+  for (const page of pages) tasks.add(page);
   console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
 }
 
 /**
- * Handle updates to an inline SVG by re-rendering dependent pages.
+ * Handle updates to inline SVGs by re-rendering dependent pages.
  *
- * @param {string} path - Path to the SVG file.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
+ * @param {string} path Path to the SVG file.
+ * @param {Set<string>} tasks Set collecting pages to render.
  */
 function handleInlineSvgUpdate(path, tasks) {
   console.log(`${getEmoji("update")} SVG UPDATED -- ${path}`);
@@ -104,17 +95,15 @@ function handleInlineSvgUpdate(path, tasks) {
     console.log(`  ${getEmoji("warning")} no pages reference this SVG`);
     return;
   }
-  for (const page of pages) {
-    tasks.set(page, workerProcessPage(page));
-  }
+  for (const page of pages) tasks.add(page);
   console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
 }
 
 /**
- * Handle a CSS asset change by updating pages that reference it.
+ * Handle updates to CSS assets by re-rendering dependent pages.
  *
- * @param {string} path - Path to the CSS asset.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
+ * @param {string} path Path to the CSS file.
+ * @param {Set<string>} tasks Set collecting pages to render.
  */
 function handleCssAsset(path, tasks) {
   console.log(`${getEmoji("update")} CSS UPDATED -- ${path}`);
@@ -123,17 +112,15 @@ function handleCssAsset(path, tasks) {
     console.log(`  ${getEmoji("warning")} no pages reference this stylesheet`);
     return;
   }
-  for (const page of pages) {
-    tasks.set(page, workerProcessPage(page));
-  }
+  for (const page of pages) tasks.add(page);
   console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
 }
 
 /**
- * Handle a JavaScript module change by updating referencing pages.
+ * Handle updates to module script assets by re-rendering dependent pages.
  *
- * @param {string} path - Path to the module file.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
+ * @param {string} path Path to the module script.
+ * @param {Set<string>} tasks Set collecting pages to render.
  */
 function handleModuleAsset(path, tasks) {
   console.log(`${getEmoji("update")} MODULE UPDATED -- ${path}`);
@@ -142,20 +129,18 @@ function handleModuleAsset(path, tasks) {
     console.log(`  ${getEmoji("warning")} no pages reference this module`);
     return;
   }
-  for (const page of pages) {
-    tasks.set(page, workerProcessPage(page));
-  }
+  for (const page of pages) tasks.add(page);
   console.log(`  ${getEmoji("update")} ${pages.length} page(s) updated`);
 }
 
 /**
- * Handle updates to generic assets and delegate to specific handlers.
+ * Copy an asset and schedule any dependent pages for re-rendering.
  *
- * @param {string} path - Path to the asset.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
+ * @param {string} path Path to the asset.
+ * @param {Set<string>} tasks Set collecting pages to render.
  */
-function handleAssetUpdate(path, tasks) {
-  workerPool.push({ type: "asset", path });
+async function handleAssetUpdate(path, tasks) {
+  await copyAsset(path);
   const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
   if (ext === ".css") {
     handleCssAsset(path, tasks);
@@ -165,37 +150,37 @@ function handleAssetUpdate(path, tasks) {
 }
 
 /**
- * Remove a page output when its source HTML is deleted.
+ * Remove the rendered output for a page whose source was deleted.
  *
- * @param {string} path - Path to the page file.
+ * @param {string} path Path to the page file.
  */
-function handlePageRemove(path) {
-  workerPool.push({ type: "remove-page", path });
+async function handlePageRemove(path) {
+  await removePage(path);
 }
 
 /**
- * Remove an asset output when deleted.
+ * Remove a copied asset when it is deleted from the source.
  *
- * @param {string} path - Path to the asset file.
+ * @param {string} path Path to the asset file.
  */
-function handleAssetRemove(path) {
-  workerPool.push({ type: "remove-asset", path });
+async function handleAssetRemove(path) {
+  await removeAsset(path);
 }
 
 /**
  * Handle removal of a template by re-rendering dependent pages.
  *
- * @param {string} path - Path to the removed template.
- * @param {Map<string, ReturnType<typeof workerProcessPage>>} tasks - Map of queued tasks.
+ * @param {string} path Path to the template file.
+ * @param {Set<string>} tasks Set collecting pages to render.
  */
 function handleTemplateRemove(path, tasks) {
   console.log(`${getEmoji("delete")} TEMPLATE REMOVED -- ${path}`);
   for (const page of pagesUsingTemplate(path)) {
-    tasks.set(page, workerProcessPage(page));
+    tasks.add(page);
   }
 }
 
-/** @type {Record<string, (p: string, t: Map<string, ReturnType<typeof workerProcessPage>>) => void>} */
+/** @type {Record<string, (p: string, t: Set<string>) => void|Promise<void>>} */
 const createModifyHandlers = {
   PAGE_HTML: handlePageHtml,
   TEMPLATE: handleTemplateUpdate,
@@ -204,91 +189,83 @@ const createModifyHandlers = {
   ASSET: handleAssetUpdate,
 };
 
-/** @type {Record<string, (p: string, t: Map<string, ReturnType<typeof workerProcessPage>>) => void>} */
+/** @type {Record<string, (p: string, t: Set<string>) => void|Promise<void>>} */
 const removeHandlers = {
-  PAGE_HTML: (p) => handlePageRemove(p),
-  ASSET: (p) => handleAssetRemove(p),
+  PAGE_HTML: (p, _t) => handlePageRemove(p),
+  ASSET: (p, _t) => handleAssetRemove(p),
   TEMPLATE: handleTemplateRemove,
 };
 
 /**
- * Watch the source and template directories for changes and trigger rebuilds.
+ * Watch the source and shared directories for changes and trigger rebuilds.
  *
- * @param {number} [workers] Number of worker threads to use.
- * @returns {Promise<void>}
+ * @returns {Promise<void>} Resolves when the watcher stops.
  */
-export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
-  workerPool = new WorkerPool(
-    new URL("./worker-task.js", import.meta.url).href,
-    workers,
-  );
+export async function watch() {
   const src = fromFileUrl(new URL("../src", import.meta.url));
-  const templates = fromFileUrl(new URL("../templates", import.meta.url));
+  const shared = fromFileUrl(new URL("../shared", import.meta.url));
 
   try {
     await Deno.mkdir(src);
-  } catch (exitErr) {
+  } catch (_err) {
     console.log(`${getEmoji("warning")} CREATE DIR /src/ -- no need it exists`);
   }
 
   try {
-    await Deno.mkdir(templates);
-  } catch (exitErr) {
+    await Deno.mkdir(shared);
+  } catch (_err) {
     console.log(
-      `${getEmoji("warning")} CREATE DIR /template/ -- no need it exists`,
+      `${getEmoji("warning")} CREATE DIR /shared/ -- no need it exists`,
     );
   }
 
   const srcWatcher = Deno.watchFs(src, { recursive: true });
   console.log(`${getEmoji("success")} CREATING WATCHER /src/`);
 
-  const templatesWatcher = Deno.watchFs(templates, { recursive: true });
-  console.log(`${getEmoji("success")} CREATED WATCHER /templates/`);
+  const sharedWatcher = Deno.watchFs(shared, { recursive: true });
+  console.log(`${getEmoji("success")} CREATED WATCHER /shared/`);
 
-  const watchers = [srcWatcher, templatesWatcher];
+  const watchers = [srcWatcher, sharedWatcher];
 
-  // Initial synchronization of existing files before processing new events
   const diffs = [
     await diffSourceFiles(src),
-    await diffSourceFiles(templates),
+    await diffSourceFiles(shared),
   ];
-  const startupTasks = new Map();
+  const startupTasks = new Set();
   for (const { added, modified, removed } of diffs) {
     for (const [p, m] of [...added, ...modified]) {
       const kind = classifyPath(p);
       const handler = createModifyHandlers[kind];
-      if (handler) handler(p, startupTasks);
+      if (handler) await handler(p, startupTasks);
       recordSourceFile(p, m);
     }
     for (const p of removed) {
       const kind = classifyPath(p);
       const handler = removeHandlers[kind];
-      if (handler) handler(p, startupTasks);
+      if (handler) await handler(p, startupTasks);
       removeSourceFile(p);
     }
   }
-  await Promise.all(
-    [...startupTasks.values()].map((t) => workerPool.push(...t)),
-  );
+  for (const p of startupTasks) await renderAndRecord(p);
 
   const queue = [];
   let timer;
 
   /**
-   * Process queued filesystem events and dispatch worker tasks.
+   * Process queued filesystem events and dispatch rendering tasks.
    *
-   * @returns {Promise<void>}
+   * @returns {Promise<void>} Resolves when processing completes.
    */
   async function flush() {
     const events = queue.splice(0);
     timer = undefined;
     const paths = reduceEvents(events);
-    const tasks = new Map();
+    const tasks = new Set();
     for (const [path, evtKind] of paths) {
       const kind = classifyPath(path);
       if (evtKind === "create" || evtKind === "modify") {
         const handler = createModifyHandlers[kind];
-        if (handler) handler(path, tasks);
+        if (handler) await handler(path, tasks);
         let mtime = 0;
         try {
           const stat = await Deno.stat(path);
@@ -299,20 +276,18 @@ export async function watch(workers = navigator.hardwareConcurrency ?? 2) {
         recordSourceFile(path, mtime);
       } else if (evtKind === "remove") {
         const handler = removeHandlers[kind];
-        if (handler) handler(path, tasks);
+        if (handler) await handler(path, tasks);
         removeSourceFile(path);
       }
     }
-    await Promise.all(
-      [...tasks.values()].map((t) => workerPool.push(...t)),
-    );
+    for (const p of tasks) await renderAndRecord(p);
   }
 
   /**
    * Consume events from a file system watcher and queue them for processing.
    *
-   * @param {Deno.FsWatcher} w - Watcher to read events from.
-   * @returns {Promise<void>}
+   * @param {Deno.FsWatcher} w Watcher to read events from.
+   * @returns {Promise<void>} Resolves when the watcher ends.
    */
   async function handle(w) {
     for await (const evt of w) {

--- a/lib/watch.test.js
+++ b/lib/watch.test.js
@@ -34,7 +34,7 @@ function denoTest() {
 
   Deno.test("classifyPath identifies types", () => {
     assertEquals(classifyPath("/src/site/page.html"), "PAGE_HTML");
-    assertEquals(classifyPath("/templates/head.js"), "TEMPLATE");
+    assertEquals(classifyPath("/shared/templates/head.js"), "TEMPLATE");
     assertEquals(classifyPath("/src/site/src-svg/icon.svg"), "SVG_INLINE");
     assertEquals(classifyPath("/src/site/foo.inline.js"), "JS_INLINE");
     assertEquals(classifyPath("/src/site/js/app.js"), "ASSET");
@@ -49,11 +49,11 @@ function denoTest() {
       pagePath: page,
       templatesUsed: ["/core/templates/head/default.js"],
     });
-    assertEquals(pagesUsingTemplate("/templates/head/default.js"), [page]);
+    assertEquals(pagesUsingTemplate("/shared/templates/head/default.js"), [page]);
     clearPageDeps();
     recordPageDeps({
       pagePath: page,
-      templatesUsed: ["/templates/head/default.js"],
+      templatesUsed: ["/shared/templates/head/default.js"],
     });
     assertEquals(pagesUsingTemplate("/core/templates/head/default.js"), [page]);
   });
@@ -148,21 +148,15 @@ function denoTest() {
       cssUsed: [cssPath],
       modulesUsed: [modulePath],
     });
-    const tasks = new Map();
+    const tasks = new Set();
     for (const p of pagesUsingCss(cssPath)) {
-      tasks.set(p, [{ type: "render", path: p }, []]);
+      tasks.add(p);
     }
     for (const p of pagesUsingModule(modulePath)) {
-      tasks.set(p, [{ type: "render", path: p }, []]);
+      tasks.add(p);
     }
     let count = 0;
-    const pool = {
-      push: () => {
-        count++;
-        return Promise.resolve();
-      },
-    };
-    await Promise.all([...tasks.values()].map((t) => pool.push(...t)));
+    for (const _p of tasks) count++;
     assertEquals(count, 1);
   });
 }

--- a/main_new.js
+++ b/main_new.js
@@ -1,228 +1,38 @@
-import *  as path from "@std/path";
-import { logWithEmoji, getEmoji } from "./lib/emoji.js";
-import { parsePage } from "./lib/parse-page.js";
-import * as store from "./lib/store.js";
-import { EXTENSIONS } from "./lib/extension-whitelist.js";
+import { parse } from "@std/flags";
+import { walk } from "@std/fs/walk";
+import { renderPage } from "./lib/render-page.js";
+import { recordPageDeps } from "./lib/page-deps.js";
+import { watch } from "./lib/watch.js";
+import { getEmoji, logWithEmoji } from "./lib/emoji.js";
 
-
-// #######################
-// DIRECTORIES
-// #######################
-
-function logDirNotExist(dir = "", signal = "info") {
-    logWithEmoji(signal, `${getEmoji("directory")} /${dir}/ directory doesn not exist!`)
+/**
+ * Render all pages under the `/src` directory sequentially.
+ *
+ * @returns {Promise<void>} Resolves when the initial build completes.
+ */
+export async function fullBuild() {
+  const root = new URL("./src", import.meta.url);
+  try {
+    for await (
+      const entry of walk(root, { includeDirs: false, exts: [".html", ".md"] })
+    ) {
+      const deps = await renderPage(entry.path);
+      if (deps) recordPageDeps(deps);
+    }
+    logWithEmoji("system", `${getEmoji("success")} BUILD -- done!`);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+    logWithEmoji("system", `${getEmoji("error")} BUILD -- failed: ${err}`);
+  }
 }
-
-function dirExists(url = new URL()) {
-    try { return Deno.statSync(url);} catch (_) { return;}
-}
-
-function dirHasEntries(url = new URL()) {
-    for (const _entry of Deno.readDirSync(url)) return true;
-    return false;
-}
-
-const rootDir = new URL(path.dirname(import.meta.url));
-const srcDir = new URL(path.join(rootDir.href, '/src/'));
-const coreDir = new URL(path.join(rootDir.href, '/core/'));
-const sharedDir = new URL(path.join(rootDir.href, '/shared/'));
-const coreTemplateDir = new URL(path.join(coreDir.href, '/templates/'));
-const coreCSSDir = new URL(path.join(coreDir.href, '/css/'));
-const coreJSDir = new URL(path.join(coreDir.href, '/js/'));
-const coreSVGDir = new URL(path.join(coreDir.href, '/svg/'));
-const sharedTemplateDir = new URL(path.join(sharedDir.href, '/templates/'));
-const sharedCSSDir = new URL(path.join(sharedDir.href, '/css/'));
-const sharedJSDir = new URL(path.join(sharedDir.href, '/js/'));
-const sharedSVGDir = new URL(path.join(sharedDir.href, '/svg/'));
-
-console.log(`rootDir: ${rootDir}`);
-
-store.directories.set("root", rootDir);
-store.directories.set("src", srcDir);
-store.directories.set("core", coreDir);
-store.directories.set("coreTemplates", coreTemplateDir);
-store.directories.set("coreCSS", coreCSSDir);
-store.directories.set("coreJS", coreJSDir);
-store.directories.set("coreSVG", coreSVGDir);
-try {
-    const _ = Deno.statSync(sharedDir.pathname.slice(0,-1));
-    store.directories.set("shared", sharedDir);
-    if (dirExists(sharedDir)) {
-        store.directories.set("sharedTemplates", sharedTemplateDir);
-    } else {
-        logDirNotExist("shared/tempates");
-    }
-    if (dirExists(sharedCSSDir)) {
-        store.directories.set("sharedCSS", sharedDir);
-    } else {
-        logDirNotExist("shared/css");
-    }
-    if (dirExists(sharedJSDir)) {
-        store.directories.set("sharedJS", sharedJSDir);
-    } else {
-        logDirNotExist("shared/js");
-    }
-    if (dirExists(sharedSVGDir)) {
-        store.directories.set("sharedSVG", sharedSVGDir);
-    } else {
-        logDirNotExist("shared/svg");
-    }
-} catch (_) {
-    logDirNotExist("shared");
-}
-// #######################
-// SCANING
-// #######################
-const unsupportedFiles = new Set();
-
-function scanSource(urlDir = new URL(), files = new Map()) {
-    logWithEmoji("search", `${getEmoji("directory")} ${urlDir.href.split(rootDir)[1]}`);
-    
-
-    for( const entry of Deno.readDirSync(urlDir)) {
-        
-        if (entry.isFile) {
-            const entryUrl = new URL(entry.name, urlDir);
-            const extension = path.extname(entryUrl.href);
-            const info = Deno.statSync(entryUrl);
-            const hostname = entryUrl.href.replace(srcDir, "").split("/")[0];
-            let file;
-            let type;
-
-            if (entryUrl.href.includes("/templates/")) {
-                store.Templates.add(entryUrl.href);
-                file = Deno.readTextFileSync(entryUrl);
-                type = "TEMPLATE";
-            } else if (entryUrl.href.includes("/css/")) {
-                store.CSS.add(entryUrl.href);
-                type = "CSS";
-            } else if (entryUrl.href.includes("/js/")) {
-                type = "JS";
-                // do nothing specific with module
-                // only load inline js
-                if (entryUrl.href.endsWith(".inline.js")) {
-                    store.JS.add(entryUrl.href);
-                    file = Deno.readTextFileSync(entryUrl);
-                }
-            } else if (entryUrl.href.includes("/media/")) {
-                if(EXTENSIONS.get("picture").has(extension)) type = "PICTURE";
-                if(EXTENSIONS.get("audio").has(extension)) type = "AUDIO";
-                if(EXTENSIONS.get("video").has(extension)) type = "VIDEO";
-                if(EXTENSIONS.get("font").has(extension)) type = "FONT";
-
-            } else if (EXTENSIONS.get("document").has(extension)) {
-                // .html, .md, .markdown, .json
-                file = Deno.readTextFileSync(entryUrl);
-                type = "DOCUMENT";            
-            } else {
-                unsupportedFiles.add(entryUrl.href);
-            }
-
-            files.set(entryUrl.href, {file, info, type, extension, hostname});
-
-        } else if (entry.isSymlink) {
-            // TODO: handle symlink use case
-        } else {
-            const entryUrl = new URL(`${entry.name}/`, urlDir);
-            scanSource(entryUrl, files);
-        }
-    }
-
-    return files;
-}
-
-function scanDir(urlDir = new URL(), items = new Set(), emoji = "file") {
-    const folderStatus = dirHasEntries(urlDir) ? "directory": "emptydirectory";
-    logWithEmoji("search", `${getEmoji(folderStatus)} ${urlDir.href.split(rootDir)[1]}`);
-    for( const entry of Deno.readDirSync(urlDir)) {
-        if (entry.isFile) {
-            const itemUrl = new URL(entry.name, urlDir);
-            items.add(itemUrl.href);
-            console.log(`      ${getEmoji(emoji)} ${entry.name}`);
-        } else if (entry.isSymlink) {
-            // TODO: handle symlink use case
-        } else {
-            const entryUrl = new URL(`${entry.name}/`, urlDir);
-            scanDir(entryUrl, items, emoji);
-        }
-    }
-
-    return items;
-} 
-
-function scan( directories = [], items = new Set(), { emoji = "file", fileType = ""}) {
-    console.log(`\n${getEmoji("search")} ${getEmoji("directories")}  SCAN -- ${fileType} Files`);
-    
-    let result = new Set();
-    for (const dir of directories) {
-        if (store.directories.has(dir)) {
-            // force return something to keep sync execution
-             result = result.union(scanDir(store.directories.get(dir), items, emoji));
-        }
-    }
-
-    return result;
-}
-
-// #######################
-// BUILD
-// #######################
-const fileTypes = new Set(["Templates", "CSS", "JS", "SVG"]);
-const emojis = new Map([
-    ["Templates", "template"],
-    ["CSS", "style"],
-    ["JS", "script"],
-    ["SVG", "svg"]
-]);
-
-async function build () {
-    
-    // 1. SCAN
-
-    console.log(`\n${getEmoji("search")} ${getEmoji("directories")}  SCAN -- Source Files`);
-    const files = scanSource(srcDir, store.files);
-    logWithEmoji("search",`${getEmoji("right")} Found ${files.size} files`);
-    let unsupportedFilesLog = `\n${getEmoji("warning")} ${getEmoji("file")} UNSUPPORTED FILES --`
-    for (const href of unsupportedFiles) {
-        unsupportedFilesLog += `    ${getEmoji("file")} ${href}`;
-    }
-
-    for (const fileType of fileTypes) {
-        const result = scan(
-            [`core${fileType}`, `shared${fileType}`],
-            new Set(),
-            {
-                emoji: emojis.get(fileType),
-                fileType
-            }
-        );
-
-        for (const href of result) {
-            const info = Deno.statSync(new URL(href));
-            const extension = path.extname(href);
-            store[fileType].add(href);
-            files.set(href, { info, extension });
-        }
- 
-    }
-
-    logWithEmoji("search", `${getEmoji("success")} SCAN -- Done`);
-
-    // 2. LOG CHANGES
-    for (const [href, file] of files) {
-        console.log(file.info);
-        return;
-    }
-
-
-}
-
-
 
 // #######################
 // CLI
 // #######################
 
 if (import.meta.main) {
-    build();
+  // parse flags for parity with previous CLI even though no worker option exists
+  parse(Deno.args);
+  await fullBuild();
+  await watch();
 }

--- a/tests/blog-template.test.js
+++ b/tests/blog-template.test.js
@@ -39,21 +39,27 @@ Deno.test("blog pages render with blog template and other templates", async () =
   );
 
   // Shared templates for head, nav, and footer
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), {
+    recursive: true,
+  });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     "export function render({ frontMatter }) { return `<title>${frontMatter.title}</title>`; }",
   );
 
-  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "nav"), {
+    recursive: true,
+  });
   await Deno.writeTextFile(
-    join(root, "templates", "nav", "default.js"),
+    join(root, "shared", "templates", "nav", "default.js"),
     "export function render() { return `<nav>Nav</nav>`; }",
   );
 
-  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "footer"), {
+    recursive: true,
+  });
   await Deno.writeTextFile(
-    join(root, "templates", "footer", "default.js"),
+    join(root, "shared", "templates", "footer", "default.js"),
     "export function render() { return `<footer>Footer</footer>`; }",
   );
 

--- a/tests/css-fallback.test.js
+++ b/tests/css-fallback.test.js
@@ -32,11 +32,11 @@ Deno.test("renderPage falls back to core css when missing", async () => {
     join(siteDir, "config.json"),
     JSON.stringify({ distantDirectory: distDir }),
   );
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
-  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
-  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "footer"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     [
       "export function render({ frontMatter }) {",
       '  const cssLinks = (frontMatter.css || []).map((href) => `<link rel=\\"stylesheet\\" href=\\"${href}\\">`).join(\"\");',
@@ -45,19 +45,19 @@ Deno.test("renderPage falls back to core css when missing", async () => {
     ].join("\n"),
   );
   await Deno.writeTextFile(
-    join(root, "templates", "nav", "default.js"),
+    join(root, "shared", "templates", "nav", "default.js"),
     "export function render(){ return `<nav></nav>`; }",
   );
   await Deno.writeTextFile(
-    join(root, "templates", "footer", "default.js"),
+    join(root, "shared", "templates", "footer", "default.js"),
     "export function render(){ return `<footer></footer>`; }",
   );
-  const pagePath = join(siteDir, "index.html");
-  const page =
-    'title = "Home"\ncss = ["styles.css"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n#---#\n<body>hi</body>';
-  await Deno.writeTextFile(pagePath, page);
-  await renderPage(pagePath, rootUrl);
-  const cssOut = join(distDir, "styles.css");
+    const pagePath = join(siteDir, "index.html");
+    const page =
+      'title = "Home"\ncss = ["css/styles.css"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n#---#\n<body>hi</body>';
+    await Deno.writeTextFile(pagePath, page);
+    await renderPage(pagePath, rootUrl);
+    const cssOut = join(distDir, "css", "styles.css");
   assert(await fileExists(cssOut));
   const outContent = await Deno.readTextFile(cssOut);
   const coreCss = fromFileUrl(new URL("../core/css/styles.css", import.meta.url));

--- a/tests/disabled-page.test.js
+++ b/tests/disabled-page.test.js
@@ -31,9 +31,9 @@ Deno.test(
       JSON.stringify({ distantDirectory: distDir }),
     );
 
-    await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+    await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
     await Deno.writeTextFile(
-      join(root, "templates", "head", "default.js"),
+      join(root, "shared", "templates", "head", "default.js"),
       "export function render() { return `<title>t</title>`; }",
     );
 

--- a/tests/e2e/incremental-flow.test.js
+++ b/tests/e2e/incremental-flow.test.js
@@ -72,9 +72,9 @@ Deno.test("incremental end-to-end flow", async () => {
   );
 
   // Prepare templates
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     [
       "export function render({ frontMatter }) {",
       '  const cssLinks = (frontMatter.css || []).map((href) => `<link rel=\\"stylesheet\\" href=\\"${href}\\">`).join(\"\");',
@@ -83,14 +83,14 @@ Deno.test("incremental end-to-end flow", async () => {
       "}",
     ].join("\n"),
   );
-  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "nav"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "nav", "default.js"),
+    join(root, "shared", "templates", "nav", "default.js"),
     "export function render() { return `<nav></nav>`; }",
   );
-  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "footer"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "footer", "default.js"),
+    join(root, "shared", "templates", "footer", "default.js"),
     "export function render() { return `<footer></footer>`; }",
   );
 
@@ -117,25 +117,26 @@ Deno.test("incremental end-to-end flow", async () => {
 
   // Step 4
   log("created source css file copied into destination folder");
-  const cssPath = join(siteDir, "styles.css");
+  await Deno.mkdir(join(siteDir, "css"), { recursive: true });
+  const cssPath = join(siteDir, "css", "styles.css");
   await Deno.writeTextFile(cssPath, "body{color:red;}");
   await copyAsset(cssPath);
-  assert(await fileExists(join(distDir, "styles.css")));
+  assert(await fileExists(join(distDir, "css", "styles.css")));
 
   // Step 5
   log("updated source html file with css link, destination file rerendered");
-  const page3 = `title = "Home"\ndescription = "My site"\ncss = ["styles.css"]\n${TPL}\n#---#\n<body>Hello</body>`;
+  const page3 = `title = "Home"\ndescription = "My site"\ncss = ["css/styles.css"]\n${TPL}\n#---#\n<body>Hello</body>`;
   await Deno.writeTextFile(pagePath, page3);
   deps = await renderPage(pagePath, rootUrl);
   if (deps) recordPageDeps(deps);
   html = await Deno.readTextFile(join(distDir, "index.html"));
-  assert(html.includes("styles.css"));
+  assert(html.includes("css/styles.css"));
 
   // Step 6
   log(
     "added nav links to source html file, destination file rerendered and links.json created",
   );
-  const page4 = `title = "Home"\ndescription = "My site"\ncss = ["styles.css"]\n${TPL}\n[links.nav]\nlabel = "Home"\n#---#\n<body>Hello</body>`;
+  const page4 = `title = "Home"\ndescription = "My site"\ncss = ["css/styles.css"]\n${TPL}\n[links.nav]\nlabel = "Home"\n#---#\n<body>Hello</body>`;
   await Deno.writeTextFile(pagePath, page4);
   deps = await renderPage(pagePath, rootUrl);
   if (deps) recordPageDeps(deps);
@@ -147,7 +148,7 @@ Deno.test("incremental end-to-end flow", async () => {
   log(
     "added footer links to source html file, destination file rerendered and links.json updated",
   );
-  const page5 = `title = "Home"\ndescription = "My site"\ncss = ["styles.css"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body>Hello</body>`;
+  const page5 = `title = "Home"\ndescription = "My site"\ncss = ["css/styles.css"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body>Hello</body>`;
   await Deno.writeTextFile(pagePath, page5);
   deps = await renderPage(pagePath, rootUrl);
   if (deps) recordPageDeps(deps);
@@ -163,7 +164,7 @@ Deno.test("incremental end-to-end flow", async () => {
 
   // Step 9
   log("added source inline script to html file, destination file rerendered");
-  const page6 = `title = "Home"\ndescription = "My site"\ncss = ["styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body>Hello</body>`;
+  const page6 = `title = "Home"\ndescription = "My site"\ncss = ["css/styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body>Hello</body>`;
   await Deno.writeTextFile(pagePath, page6);
   deps = await renderPage(pagePath, rootUrl);
   if (deps) recordPageDeps(deps);
@@ -184,7 +185,7 @@ Deno.test("incremental end-to-end flow", async () => {
 
   // Step 11
   log("added source javascript module to html file, destination file rerendered");
-  const page7 = `title = "Home"\ndescription = "My site"\ncss = ["styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\nmodules = ["/js/app.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body>Hello</body>`;
+  const page7 = `title = "Home"\ndescription = "My site"\ncss = ["css/styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\nmodules = ["/js/app.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body>Hello</body>`;
   await Deno.writeTextFile(pagePath, page7);
   deps = await renderPage(pagePath, rootUrl);
   if (deps) recordPageDeps(deps);
@@ -202,7 +203,7 @@ Deno.test("incremental end-to-end flow", async () => {
 
   // Step 13
   log("added <icon src=\"file.svg\"></icon> to html file, destination file rerendered");
-  const page8 = `title = "Home"\ndescription = "My site"\ncss = ["styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\nmodules = ["/js/app.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body><icon src="file.svg"></icon></body>`;
+  const page8 = `title = "Home"\ndescription = "My site"\ncss = ["css/styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\nmodules = ["/js/app.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body><icon src="file.svg"></icon></body>`;
   await Deno.writeTextFile(pagePath, page8);
   deps = await renderPage(pagePath, rootUrl);
   if (deps) recordPageDeps(deps);
@@ -212,7 +213,7 @@ Deno.test("incremental end-to-end flow", async () => {
 
   // Step 14
   log("added <logo src=\"file.svg\"></logo> to html file, destination file rerendered");
-  const page9 = `title = "Home"\ndescription = "My site"\ncss = ["styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\nmodules = ["/js/app.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body><icon src="file.svg"></icon><logo src="file.svg"></logo></body>`;
+  const page9 = `title = "Home"\ndescription = "My site"\ncss = ["css/styles.css"]\n[scripts]\ninline = ["inline.inline.js"]\nmodules = ["/js/app.js"]\n${TPL}\n[links.nav]\nlabel = "Home"\n[links.footer]\nlabel = "Docs"\n#---#\n<body><icon src="file.svg"></icon><logo src="file.svg"></logo></body>`;
   await Deno.writeTextFile(pagePath, page9);
   deps = await renderPage(pagePath, rootUrl);
   if (deps) recordPageDeps(deps);

--- a/tests/e2e/watch-file-types.test.js
+++ b/tests/e2e/watch-file-types.test.js
@@ -55,9 +55,9 @@ Deno.test({
       JSON.stringify({ distantDirectory: distDir, hashAssets: true }),
     );
 
-    await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+    await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
     await Deno.writeTextFile(
-      join(root, "templates", "head", "default.js"),
+      join(root, "shared", "templates", "head", "default.js"),
       [
         "export function render({ frontMatter }) {",
         '  const cssLinks = (frontMatter.css || []).map((href) => `<link rel=\\"stylesheet\\" href=\\"${href}\\">`).join(\'\');',
@@ -66,7 +66,8 @@ Deno.test({
       ].join("\n"),
     );
 
-    const cssPath = join(siteDir, "styles.css");
+    await Deno.mkdir(join(siteDir, "css"), { recursive: true });
+    const cssPath = join(siteDir, "css", "styles.css");
     await Deno.writeTextFile(cssPath, "body{color:red;}");
     const jsDir = join(siteDir, "js");
     await Deno.mkdir(jsDir, { recursive: true });
@@ -78,7 +79,7 @@ Deno.test({
     const pagePath = join(siteDir, "index.html");
     const page = [
       'title = "Watch"',
-      'css = ["styles.css"]',
+      'css = ["css/styles.css"]',
       "[scripts]",
       'modules = ["/js/app.js"]',
       "[templates]",
@@ -142,10 +143,10 @@ Deno.test({
     assert(!html.includes(cssHash1));
     assert(!html.includes(jsHash1));
 
-    const cssOutOld = join(distDir, cssHash1);
-    const jsOutOld = join(distDir, "js", jsHash1);
-    const cssOutNew = join(distDir, cssHash2);
-    const jsOutNew = join(distDir, "js", jsHash2);
+      const cssOutOld = join(distDir, "css", cssHash1);
+      const jsOutOld = join(distDir, "js", jsHash1);
+      const cssOutNew = join(distDir, "css", cssHash2);
+      const jsOutNew = join(distDir, "js", jsHash2);
     assert(!(await fileExists(cssOutOld)));
     assert(!(await fileExists(jsOutOld)));
     assert(await fileExists(cssOutNew));

--- a/tests/inline-scripts.test.js
+++ b/tests/inline-scripts.test.js
@@ -45,9 +45,9 @@ Deno.test("inline scripts are inlined and not copied", async () => {
     "console.log('inline');",
   );
 
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     "export function render() { return `<title>Inline</title>`; }",
   );
 

--- a/tests/pretty-urls.test.js
+++ b/tests/pretty-urls.test.js
@@ -22,19 +22,19 @@ Deno.test("renderPage supports prettyUrls", async () => {
   await Deno.mkdir(siteDir, { recursive: true });
   await Deno.mkdir(distDir, { recursive: true });
 
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
-  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
-  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "footer"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     "export function render() { return `<title></title>`; }",
   );
   await Deno.writeTextFile(
-    join(root, "templates", "nav", "default.js"),
+    join(root, "shared", "templates", "nav", "default.js"),
     "export function render() { return ``; }",
   );
   await Deno.writeTextFile(
-    join(root, "templates", "footer", "default.js"),
+    join(root, "shared", "templates", "footer", "default.js"),
     "export function render() { return ``; }",
   );
 

--- a/tests/render-markdown.test.js
+++ b/tests/render-markdown.test.js
@@ -24,9 +24,9 @@ Deno.test("renderPage converts markdown sources", async () => {
     JSON.stringify({ distantDirectory: distDir }),
   );
 
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     "export function render({ frontMatter }) { return `<title>${frontMatter.title}</title>`; }",
   );
 

--- a/tests/render-page.test.js
+++ b/tests/render-page.test.js
@@ -39,12 +39,16 @@ Deno.test("renderPage renders page and updates links", async () => {
     "<svg><path/></svg>",
   );
 
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
-  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
-  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), {
+    recursive: true,
+  });
+  await Deno.mkdir(join(root, "shared", "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "footer"), {
+    recursive: true,
+  });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     [
       "export function render({ frontMatter }) {",
       '  const cssLinks = (frontMatter.css || []).map((href) => `<link rel=\\"stylesheet\\" href=\\"${href}\\">`).join(\'\');',
@@ -52,21 +56,21 @@ Deno.test("renderPage renders page and updates links", async () => {
       "}",
     ].join("\n"),
   );
-  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "nav"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "nav", "default.js"),
+    join(root, "shared", "templates", "nav", "default.js"),
     "export function render() { return `<nav>nav</nav>`; }",
   );
-  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "footer"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "footer", "default.js"),
+    join(root, "shared", "templates", "footer", "default.js"),
     "export function render() { return `<footer>foot</footer>`; }",
   );
 
   await Deno.mkdir(join(siteDir, "blog"), { recursive: true });
   const pagePath = join(siteDir, "blog", "index.html");
   const page =
-    `title = "Hello"\ncss = ["styles.css"]\n[scripts]\nmodules = ["/js/app.js"]\ninline = ["inline.inline.js"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n[links.nav]\ntopLevel = true\nlabel = "Home"\n#---#\n<body><icon src="ui/check.svg"></icon></body>`;
+    `title = "Hello"\ncss = ["css/styles.css"]\n[scripts]\nmodules = ["/js/app.js"]\ninline = ["inline.inline.js"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n[links.nav]\ntopLevel = true\nlabel = "Home"\n#---#\n<body><icon src="ui/check.svg"></icon></body>`;
   await Deno.writeTextFile(pagePath, page);
 
   const deps = await renderPage(pagePath, rootUrl);
@@ -83,7 +87,7 @@ Deno.test("renderPage renders page and updates links", async () => {
   assert(doc.querySelector("footer")?.textContent === "foot");
   const links = doc.querySelectorAll('link[rel="stylesheet"]');
   assertEquals(links.length, 1);
-  assert(links[0].getAttribute("href") === "styles.css");
+  assert(links[0].getAttribute("href") === "css/styles.css");
   assert(
     doc.querySelector('script[type="module"][src="/js/app.js"]'),
   );
@@ -125,13 +129,14 @@ Deno.test("renderPage hashes asset references when enabled", async () => {
     join(siteDir, "config.json"),
     JSON.stringify({ distantDirectory: distDir, hashAssets: true }),
   );
-  await Deno.writeTextFile(join(siteDir, "styles.css"), "body{}");
+  await Deno.mkdir(join(siteDir, "css"), { recursive: true });
+  await Deno.writeTextFile(join(siteDir, "css", "styles.css"), "body{}");
   await Deno.mkdir(join(siteDir, "js"), { recursive: true });
   await Deno.writeTextFile(join(siteDir, "js", "app.js"), "console.log('hi')");
 
-  await Deno.mkdir(join(root, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "head"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "head", "default.js"),
+    join(root, "shared", "templates", "head", "default.js"),
     [
       "export function render({ frontMatter }) {",
       '  const cssLinks = (frontMatter.css || []).map((href) => `<link rel=\\"stylesheet\\" href=\\"${href}\\">`).join(\'\');',
@@ -139,33 +144,34 @@ Deno.test("renderPage hashes asset references when enabled", async () => {
       "}",
     ].join("\n"),
   );
-  await Deno.mkdir(join(root, "templates", "nav"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "nav"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "nav", "default.js"),
+    join(root, "shared", "templates", "nav", "default.js"),
     "export function render() { return `<nav>nav</nav>`; }",
   );
-  await Deno.mkdir(join(root, "templates", "footer"), { recursive: true });
+  await Deno.mkdir(join(root, "shared", "templates", "footer"), { recursive: true });
   await Deno.writeTextFile(
-    join(root, "templates", "footer", "default.js"),
+    join(root, "shared", "templates", "footer", "default.js"),
     "export function render() { return `<footer>foot</footer>`; }",
   );
 
   await Deno.mkdir(join(siteDir, "blog"), { recursive: true });
   const pagePath = join(siteDir, "blog", "index.html");
   const page =
-    `title = "Hello"\ncss = ["styles.css"]\n[scripts]\nmodules = ["/js/app.js"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n#---#\n<body>hi</body>`;
+    `title = "Hello"\ncss = ["css/styles.css"]\n[scripts]\nmodules = ["/js/app.js"]\n[templates]\nhead = "default"\nnav = "default"\nfooter = "default"\n#---#\n<body>hi</body>`;
   await Deno.writeTextFile(pagePath, page);
 
   await renderPage(pagePath, rootUrl);
 
-  const hashedCss = await hashAssetName(join(siteDir, "styles.css"));
-  const hashedJs = await hashAssetName(join(siteDir, "js", "app.js"));
-  const outPath = join(distDir, "blog", "index.html");
-  const html = await Deno.readTextFile(outPath);
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, "text/html");
-  assert(doc);
-  const link = doc.querySelector('link[rel="stylesheet"]');
-  assert(link?.getAttribute("href") === hashedCss);
-  assert(doc.querySelector(`script[type="module"][src="/js/${hashedJs}"]`));
+    const hashedCss = await hashAssetName(join(siteDir, "css", "styles.css"));
+    const hashedJs = await hashAssetName(join(siteDir, "js", "app.js"));
+    const outPath = join(distDir, "blog", "index.html");
+    const html = await Deno.readTextFile(outPath);
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    assert(doc);
+    const link = doc.querySelector('link[rel="stylesheet"]');
+    const expectedCss = `css/${hashedCss}`;
+    assert(link?.getAttribute("href") === expectedCss);
+    assert(doc.querySelector(`script[type="module"][src="/js/${hashedJs}"]`));
 });

--- a/tests/watch-inline-scripts.test.js
+++ b/tests/watch-inline-scripts.test.js
@@ -31,9 +31,9 @@ Deno.test("watch re-renders pages when inline scripts change", async () => {
   const scriptFile = join(siteDir, "foo.inline.js");
   await Deno.writeTextFile(scriptFile, "console.log('one');");
 
-  await Deno.mkdir(join(rootDir, "templates", "head"), { recursive: true });
+  await Deno.mkdir(join(rootDir, "shared", "templates", "head"), { recursive: true });
   await Deno.writeTextFile(
-    join(rootDir, "templates", "head", "default.js"),
+    join(rootDir, "shared", "templates", "head", "default.js"),
     "export function render() { return `<title>Watch</title>`; }",
   );
 
@@ -75,5 +75,5 @@ Deno.test("watch re-renders pages when inline scripts change", async () => {
   html = await Deno.readTextFile(outPath);
   assert(html.includes('console.log("two")'));
 
-  await Deno.remove(join(rootDir, "templates"), { recursive: true });
+  await Deno.remove(join(rootDir, "shared"), { recursive: true });
 });

--- a/tests/watch-links.test.js
+++ b/tests/watch-links.test.js
@@ -25,14 +25,14 @@ Deno.test(
       JSON.stringify({ distantDirectory: distDir }),
     );
 
-    await Deno.mkdir(join(rootDir, "templates", "head"), { recursive: true });
+    await Deno.mkdir(join(rootDir, "shared", "templates", "head"), { recursive: true });
     await Deno.writeTextFile(
-      join(rootDir, "templates", "head", "default.js"),
+      join(rootDir, "shared", "templates", "head", "default.js"),
       "export function render() { return `<title>Watch</title>`; }",
     );
-    await Deno.mkdir(join(rootDir, "templates", "nav"), { recursive: true });
+    await Deno.mkdir(join(rootDir, "shared", "templates", "nav"), { recursive: true });
     await Deno.writeTextFile(
-      join(rootDir, "templates", "nav", "default.js"),
+      join(rootDir, "shared", "templates", "nav", "default.js"),
       "export function render({ links }) { return `<nav>${links.nav.map(l=>l.label).join(',')}</nav>`; }",
     );
 

--- a/tests/watch-templates.test.js
+++ b/tests/watch-templates.test.js
@@ -45,8 +45,8 @@ Deno.test(
     let html = await Deno.readTextFile(outPath);
     assert(html.includes("<title>Core</title>"));
 
-    const tplPath = join(rootDir, "templates", "head", "default.js");
-    await Deno.mkdir(join(rootDir, "templates", "head"), { recursive: true });
+    const tplPath = join(rootDir, "shared", "templates", "head", "default.js");
+    await Deno.mkdir(join(rootDir, "shared", "templates", "head"), { recursive: true });
     await Deno.writeTextFile(
       tplPath,
       "export function render() { return `<title>Override</title>`; }",


### PR DESCRIPTION
## Summary
- build pages sequentially using new main_new entrypoint
- replace worker-based watcher with single-threaded implementation
- simplify watch tests for set-based dedupe
- restore parsePage path support and auto-derive project root during rendering
- resolve page dependencies from site, shared, or core folders with shared watcher support

## Testing
- `deno test -A --import-map=import_map.json --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_b_68b7e68b5e1c832d93f33aca57bc73e9